### PR TITLE
Stronger trainers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ build/
 .projects/ARM/
 *.diff
 porymap.project.cfg
+stronger_trainers.sh

--- a/src/data/trainer_parties.h
+++ b/src/data/trainer_parties.h
@@ -1,11 +1,11 @@
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Archie1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_HUNTAIL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_SHARPEDO
     }
@@ -13,12 +13,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Archie1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_POOCHYENA
     }
@@ -26,22 +26,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt2[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_ZUBAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_CARVANHA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_POOCHYENA
     }
@@ -49,12 +49,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt3[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_CARVANHA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_ZUBAT
     }
@@ -62,7 +62,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt4[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_CARVANHA
     }
@@ -70,12 +70,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt5[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_CARVANHA
     }
@@ -83,7 +83,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt6[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_CARVANHA
     }
@@ -91,17 +91,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt6[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt7[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_ZUBAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_CARVANHA
     }
@@ -109,7 +109,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt7[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt8[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_WAILMER
     }
@@ -117,7 +117,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt8[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt9[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_POOCHYENA
     }
@@ -125,12 +125,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt9[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt10[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_POOCHYENA
     }
@@ -138,12 +138,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt10[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt11[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_POOCHYENA
     }
@@ -151,12 +151,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt11[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt12[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_POOCHYENA
     }
@@ -164,12 +164,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt12[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt13[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_ZUBAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_POOCHYENA
     }
@@ -177,12 +177,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt13[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt14[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_ZUBAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_POOCHYENA
     }
@@ -190,7 +190,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt14[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt15[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 11,
 	.species = SPECIES_POOCHYENA
     }
@@ -198,12 +198,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt15[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt16[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_ZUBAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_POOCHYENA
     }
@@ -211,12 +211,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt16[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt17[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_CARVANHA
     }
@@ -224,17 +224,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt17[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt18[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_ZUBAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_CARVANHA
     }
@@ -242,7 +242,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt18[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt19[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_CARVANHA
     }
@@ -250,12 +250,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt19[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt20[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 14,
 	.species = SPECIES_ZUBAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 14,
 	.species = SPECIES_CARVANHA
     }
@@ -263,7 +263,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt20[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt21[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_WAILMER
     }
@@ -271,17 +271,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt21[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt22[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_ZUBAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_ZUBAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_ZUBAT
     }
@@ -289,12 +289,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt22[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt23[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_CARVANHA
     }
@@ -302,12 +302,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt23[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt24[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_CARVANHA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_CARVANHA
     }
@@ -315,7 +315,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt24[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt25[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_CARVANHA
     }
@@ -323,17 +323,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt25[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt26[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_CARVANHA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_CARVANHA
     }
@@ -341,7 +341,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt26[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt27[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_ZUBAT
     }
@@ -349,12 +349,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt27[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous1[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_PELIPPER
     }
@@ -362,17 +362,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Matt1[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_CARVANHA
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_MIGHTYENA
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_SHARPEDO
     }
@@ -380,17 +380,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Matt1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Matt2[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_CARVANHA
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_CARVANHA
     }
@@ -398,12 +398,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Matt2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shelly1[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_CARVANHA
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_MIGHTYENA
     }
@@ -411,12 +411,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shelly1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shelly2[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_SHARPEDO
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_MIGHTYENA
     }
@@ -424,17 +424,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shelly2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Archie2[] = {
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 41,
 	.species = SPECIES_MIGHTYENA
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 41,
 	.species = SPECIES_CROBAT
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_SHARPEDO
     }
@@ -442,17 +442,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Archie2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Archie3[] = {
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_MIGHTYENA
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_GOLBAT
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_SHARPEDO
     }
@@ -460,7 +460,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Archie3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Daisy[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_ROSELIA
     }
@@ -468,12 +468,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Daisy[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Rose1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_ROSELIA
     }
@@ -481,12 +481,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Rose1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lily[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_ROSELIA
     }
@@ -494,17 +494,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lily[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Violet[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_GLOOM
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_BRELOOM
     }
@@ -512,12 +512,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Violet[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Rose2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_ROSELIA
     }
@@ -525,17 +525,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Rose2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Rose3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_GLOOM
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_ROSELIA
     }
@@ -543,17 +543,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Rose3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Rose4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_GLOOM
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_ROSELIA
     }
@@ -561,17 +561,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Rose4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Rose5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_BRELOOM
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_GLOOM
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_ROSELIA
     }
@@ -579,7 +579,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Rose5[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Dusty1[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_SANDSLASH,
         .moves = MOVE_DIG, MOVE_SLASH, MOVE_SAND_ATTACK, MOVE_POISON_STING
@@ -588,19 +588,19 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Dusty1[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Chip[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_SANDSHREW,
         .moves = MOVE_DIG, MOVE_SLASH, MOVE_SAND_ATTACK, MOVE_POISON_STING
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_SANDSHREW,
         .moves = MOVE_DIG, MOVE_SLASH, MOVE_SAND_ATTACK, MOVE_POISON_STING
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_SANDSLASH,
         .moves = MOVE_DIG, MOVE_SLASH, MOVE_SAND_ATTACK, MOVE_POISON_STING
@@ -609,13 +609,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Chip[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Foster[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_SANDSHREW,
         .moves = MOVE_DIG, MOVE_SLASH, MOVE_SAND_ATTACK, MOVE_POISON_STING
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_SANDSLASH,
         .moves = MOVE_DIG, MOVE_SLASH, MOVE_SAND_ATTACK, MOVE_POISON_STING
@@ -624,7 +624,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Foster[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Dusty2[] = {
     {
-	.iv = 60,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_SANDSLASH,
         .moves = MOVE_DIG, MOVE_SLASH, MOVE_SAND_ATTACK, MOVE_POISON_STING
@@ -633,7 +633,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Dusty2[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Dusty3[] = {
     {
-	.iv = 70,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_SANDSLASH,
         .moves = MOVE_DIG, MOVE_SLASH, MOVE_SAND_ATTACK, MOVE_POISON_STING
@@ -642,7 +642,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Dusty3[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Dusty4[] = {
     {
-	.iv = 80,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_SANDSLASH,
         .moves = MOVE_DIG, MOVE_SLASH, MOVE_SAND_ATTACK, MOVE_POISON_STING
@@ -651,7 +651,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Dusty4[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Dusty5[] = {
     {
-	.iv = 90,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_SANDSLASH,
         .moves = MOVE_DIG, MOVE_SLASH, MOVE_SAND_ATTACK, MOVE_POISON_STING
@@ -660,12 +660,12 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Dusty5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_GabbyAndTy1[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_MAGNEMITE
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_WHISMUR
     }
@@ -673,12 +673,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_GabbyAndTy1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_GabbyAndTy2[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_MAGNEMITE
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_LOUDRED
     }
@@ -686,12 +686,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_GabbyAndTy2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_GabbyAndTy3[] = {
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_MAGNETON
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_LOUDRED
     }
@@ -699,12 +699,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_GabbyAndTy3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_GabbyAndTy4[] = {
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_MAGNETON
     },
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_LOUDRED
     }
@@ -712,12 +712,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_GabbyAndTy4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_GabbyAndTy5[] = {
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_MAGNETON
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_LOUDRED
     }
@@ -725,13 +725,13 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_GabbyAndTy5[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_GabbyAndTy6[] = {
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_MAGNETON,
         .moves = MOVE_SONIC_BOOM, MOVE_THUNDER_WAVE, MOVE_METAL_SOUND, MOVE_THUNDERBOLT
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_EXPLOUD,
         .moves = MOVE_ASTONISH, MOVE_STOMP, MOVE_SUPERSONIC, MOVE_HYPER_VOICE
@@ -740,12 +740,12 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_GabbyAndTy6[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lola1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 13,
 	.species = SPECIES_AZURILL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 13,
 	.species = SPECIES_AZURILL
     }
@@ -753,7 +753,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lola1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Carmen[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_MARILL
     }
@@ -761,7 +761,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Carmen[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Gwen[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_MARILL
     }
@@ -769,12 +769,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Gwen[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lola2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_MARILL
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_MARILL
     }
@@ -782,12 +782,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lola2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lola3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_MARILL
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_MARILL
     }
@@ -795,12 +795,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lola3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lola4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_MARILL
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_MARILL
     }
@@ -808,12 +808,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lola4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lola5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_AZUMARILL
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_AZUMARILL
     }
@@ -821,7 +821,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lola5[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Ricky1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 14,
 	.species = SPECIES_ZIGZAGOON,
         .moves = MOVE_SAND_ATTACK, MOVE_HEADBUTT, MOVE_TAIL_WHIP, MOVE_SURF
@@ -830,12 +830,12 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Ricky1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Simon[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_AZURILL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_MARILL
     }
@@ -843,7 +843,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Simon[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Charlie[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_MARILL
     }
@@ -851,7 +851,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Charlie[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Ricky2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_LINOONE,
         .moves = MOVE_SAND_ATTACK, MOVE_PIN_MISSILE, MOVE_TAIL_WHIP, MOVE_SURF
@@ -860,7 +860,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Ricky2[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Ricky3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_LINOONE,
         .moves = MOVE_SAND_ATTACK, MOVE_PIN_MISSILE, MOVE_TAIL_WHIP, MOVE_SURF
@@ -869,7 +869,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Ricky3[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Ricky4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_LINOONE,
         .moves = MOVE_SAND_ATTACK, MOVE_PIN_MISSILE, MOVE_TAIL_WHIP, MOVE_SURF
@@ -878,7 +878,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Ricky4[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Ricky5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_LINOONE,
         .moves = MOVE_SAND_ATTACK, MOVE_PIN_MISSILE, MOVE_TAIL_WHIP, MOVE_SURF
@@ -887,7 +887,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Ricky5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Randall[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_DELCATTY
     }
@@ -895,7 +895,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Randall[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Parker[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_LINOONE
     }
@@ -903,7 +903,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Parker[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_George[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_LINOONE
     }
@@ -911,7 +911,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_George[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Berke[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_ZANGOOSE
     }
@@ -919,31 +919,31 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Berke[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Clyde[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_SWELLOW,
         .moves = MOVE_FOCUS_ENERGY, MOVE_QUICK_ATTACK, MOVE_WING_ATTACK, MOVE_ENDEAVOR
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_TRAPINCH,
         .moves = MOVE_BITE, MOVE_DIG, MOVE_FAINT_ATTACK, MOVE_SAND_TOMB
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_WAILMER,
         .moves = MOVE_ROLLOUT, MOVE_WHIRLPOOL, MOVE_ASTONISH, MOVE_WATER_PULSE
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_MAGNETON,
         .moves = MOVE_THUNDERBOLT, MOVE_SUPERSONIC, MOVE_THUNDER_WAVE, MOVE_SONIC_BOOM
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_SHIFTRY,
         .moves = MOVE_GIGA_DRAIN, MOVE_FAINT_ATTACK, MOVE_DOUBLE_TEAM, MOVE_SWAGGER
@@ -952,17 +952,17 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Clyde[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Vincent[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 44,
 	.species = SPECIES_SABLEYE
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 44,
 	.species = SPECIES_MEDICHAM
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 44,
 	.species = SPECIES_SHARPEDO
     }
@@ -970,12 +970,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Vincent[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Leroy[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 46,
 	.species = SPECIES_MAWILE
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 46,
 	.species = SPECIES_STARMIE
     }
@@ -983,17 +983,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Leroy[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Wilton1[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_ELECTRIKE
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_MAKUHITA
     }
@@ -1001,7 +1001,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Wilton1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Edgar[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 44,
 	.species = SPECIES_CACTURNE
     }
@@ -1009,12 +1009,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Edgar[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Albert[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_MANECTRIC
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_MUK
     }
@@ -1022,17 +1022,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Albert[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Samuel[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_DODRIO
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_LAIRON
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_KADABRA
     }
@@ -1040,22 +1040,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Samuel[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Vito[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_KADABRA
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_MANECTRIC
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_SHIFTRY
     }
@@ -1063,17 +1063,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Vito[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Owen[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_KECLEON
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_RHYHORN
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_TENTACRUEL
     }
@@ -1081,17 +1081,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Owen[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Wilton2[] = {
     {
-	.iv = 110,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_ELECTRIKE
     },
     {
-	.iv = 110,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 110,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_MAKUHITA
     }
@@ -1099,17 +1099,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Wilton2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Wilton3[] = {
     {
-	.iv = 120,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_MANECTRIC
     },
     {
-	.iv = 120,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 120,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_MAKUHITA
     }
@@ -1117,17 +1117,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Wilton3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Wilton4[] = {
     {
-	.iv = 130,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_MANECTRIC
     },
     {
-	.iv = 130,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 130,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_MAKUHITA
     }
@@ -1135,17 +1135,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Wilton4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Wilton5[] = {
     {
-	.iv = 140,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_MANECTRIC
     },
     {
-	.iv = 140,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 140,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_HARIYAMA
     }
@@ -1153,17 +1153,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Wilton5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Warren[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_GRAVELER
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_MAGCARGO
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_LUDICOLO
     }
@@ -1171,7 +1171,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Warren[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Mary[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_DELCATTY
     }
@@ -1179,7 +1179,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Mary[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lori[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_LINOONE
     }
@@ -1187,7 +1187,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lori[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jody[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_ZANGOOSE
     }
@@ -1195,19 +1195,19 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jody[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Wendy[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_MAWILE,
         .moves = MOVE_BATON_PASS, MOVE_FAINT_ATTACK, MOVE_FAKE_TEARS, MOVE_BITE
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_ROSELIA,
         .moves = MOVE_MEGA_DRAIN, MOVE_MAGICAL_LEAF, MOVE_GRASS_WHISTLE, MOVE_LEECH_SEED
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_PELIPPER,
         .moves = MOVE_FLY, MOVE_WATER_GUN, MOVE_MIST, MOVE_PROTECT
@@ -1216,12 +1216,12 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Wendy[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Elaine[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 45,
 	.species = SPECIES_LAIRON
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 45,
 	.species = SPECIES_MANECTRIC
     }
@@ -1229,17 +1229,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Elaine[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brooke1[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_ROSELIA
     }
@@ -1247,7 +1247,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brooke1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jennifer[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_MILOTIC
     }
@@ -1255,7 +1255,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jennifer[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Hope[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 44,
 	.species = SPECIES_ROSELIA
     }
@@ -1263,7 +1263,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Hope[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shannon[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 44,
 	.species = SPECIES_CLAYDOL
     }
@@ -1271,17 +1271,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shannon[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Michelle[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_NOSEPASS
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_MEDICHAM
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_LUDICOLO
     }
@@ -1289,12 +1289,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Michelle[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Caroline[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_MAWILE
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_SABLEYE
     }
@@ -1302,12 +1302,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Caroline[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Julie[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_SANDSLASH
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_NINETALES
     }
@@ -1315,17 +1315,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Julie[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brooke2[] = {
     {
-	.iv = 110,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 110,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 110,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_ROSELIA
     }
@@ -1333,17 +1333,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brooke2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brooke3[] = {
     {
-	.iv = 120,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_PELIPPER
     },
     {
-	.iv = 120,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 120,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_ROSELIA
     }
@@ -1351,17 +1351,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brooke3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brooke4[] = {
     {
-	.iv = 130,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_PELIPPER
     },
     {
-	.iv = 130,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 130,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_ROSELIA
     }
@@ -1369,17 +1369,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brooke4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brooke5[] = {
     {
-	.iv = 140,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_PELIPPER
     },
     {
-	.iv = 140,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_CAMERUPT
     },
     {
-	.iv = 140,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_ROSELIA
     }
@@ -1387,7 +1387,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brooke5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Patricia[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_BANETTE
     }
@@ -1395,12 +1395,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Patricia[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kindra[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_DUSKULL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SHUPPET
     }
@@ -1408,12 +1408,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kindra[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tammy[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_RALTS
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_DUSKULL
     }
@@ -1421,7 +1421,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tammy[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Valerie1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_SABLEYE
     }
@@ -1429,12 +1429,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Valerie1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tasha[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SHUPPET
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_KADABRA
     }
@@ -1442,7 +1442,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tasha[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Valerie2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_SABLEYE
     }
@@ -1450,12 +1450,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Valerie2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Valerie3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_SPOINK
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_SABLEYE
     }
@@ -1463,12 +1463,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Valerie3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Valerie4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_SPOINK
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_SABLEYE
     }
@@ -1476,17 +1476,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Valerie4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Valerie5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_DUSKULL
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_SABLEYE
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_GRUMPIG
     }
@@ -1494,7 +1494,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Valerie5[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Cindy1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 7,
 	.species = SPECIES_ZIGZAGOON,
         .heldItem = ITEM_NUGGET
@@ -1503,7 +1503,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Cindy1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous2[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_SWABLU
     }
@@ -1511,13 +1511,13 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous2[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Brianna1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 10,
 	.species = SPECIES_WYNAUT,
         .moves = MOVE_CHARM, MOVE_ENCORE, MOVE_NONE, MOVE_NONE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 10,
 	.species = SPECIES_TAILLOW,
         .moves = MOVE_QUICK_ATTACK, MOVE_GROWL, MOVE_NONE, MOVE_NONE
@@ -1526,7 +1526,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Brianna1[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Cindy2[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 11,
 	.species = SPECIES_ZIGZAGOON,
         .moves = MOVE_TACKLE, MOVE_TAIL_WHIP, MOVE_NONE, MOVE_NONE
@@ -1535,7 +1535,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Cindy2[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Brianna2[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 41,
 	.species = SPECIES_SEAKING,
         .heldItem = ITEM_NUGGET
@@ -1544,7 +1544,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Brianna2[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Anette[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 45,
 	.species = SPECIES_ROSELIA,
         .heldItem = ITEM_NUGGET
@@ -1553,7 +1553,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Anette[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Cindy3[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_LINOONE,
         .heldItem = ITEM_NUGGET
@@ -1562,7 +1562,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Cindy3[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Cindy4[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_LINOONE,
         .heldItem = ITEM_NUGGET
@@ -1571,7 +1571,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Cindy4[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Cindy5[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_LINOONE,
         .heldItem = ITEM_NUGGET
@@ -1580,7 +1580,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Cindy5[] = {
 
 const struct TrainerMonItemCustomMoves gTrainerParty_Cindy6[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_LINOONE,
         .heldItem = ITEM_NUGGET,
@@ -1590,7 +1590,7 @@ const struct TrainerMonItemCustomMoves gTrainerParty_Cindy6[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Melissa[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_MARILL
     }
@@ -1598,7 +1598,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Melissa[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Sheila[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_SHROOMISH
     }
@@ -1606,7 +1606,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Sheila[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shirley[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_NUMEL
     }
@@ -1614,13 +1614,13 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shirley[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Jessica1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_KECLEON,
         .moves = MOVE_BIND, MOVE_LICK, MOVE_FURY_SWIPES, MOVE_FAINT_ATTACK
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_SEVIPER,
         .moves = MOVE_POISON_TAIL, MOVE_SCREECH, MOVE_GLARE, MOVE_CRUNCH
@@ -1629,12 +1629,12 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Jessica1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Connie[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_GOLDEEN
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_WAILMER
     }
@@ -1642,7 +1642,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Connie[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Bridget[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 41,
 	.species = SPECIES_AZUMARILL
     }
@@ -1650,7 +1650,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Bridget[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Olivia[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 41,
 	.species = SPECIES_LOMBRE,
         .moves = MOVE_UPROAR, MOVE_FURY_SWIPES, MOVE_FAKE_OUT, MOVE_WATER_GUN
@@ -1659,17 +1659,17 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Olivia[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tiffany[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_CARVANHA
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_SHARPEDO
     }
@@ -1677,13 +1677,13 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tiffany[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Jessica2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_KECLEON,
         .moves = MOVE_BIND, MOVE_LICK, MOVE_FURY_SWIPES, MOVE_FAINT_ATTACK
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_SEVIPER,
         .moves = MOVE_POISON_TAIL, MOVE_SCREECH, MOVE_GLARE, MOVE_CRUNCH
@@ -1692,13 +1692,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Jessica2[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Jessica3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_KECLEON,
         .moves = MOVE_BIND, MOVE_LICK, MOVE_FURY_SWIPES, MOVE_FAINT_ATTACK
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_SEVIPER,
         .moves = MOVE_POISON_TAIL, MOVE_SCREECH, MOVE_GLARE, MOVE_CRUNCH
@@ -1707,13 +1707,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Jessica3[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Jessica4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_KECLEON,
         .moves = MOVE_BIND, MOVE_LICK, MOVE_FURY_SWIPES, MOVE_FAINT_ATTACK
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_SEVIPER,
         .moves = MOVE_POISON_TAIL, MOVE_SCREECH, MOVE_GLARE, MOVE_CRUNCH
@@ -1722,13 +1722,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Jessica4[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Jessica5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_KECLEON,
         .moves = MOVE_BIND, MOVE_LICK, MOVE_FURY_SWIPES, MOVE_FAINT_ATTACK
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_SEVIPER,
         .moves = MOVE_POISON_TAIL, MOVE_SCREECH, MOVE_GLARE, MOVE_CRUNCH
@@ -1737,7 +1737,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Jessica5[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Winston1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 7,
 	.species = SPECIES_ZIGZAGOON,
         .heldItem = ITEM_NUGGET
@@ -1746,7 +1746,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Winston1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous3[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_NUMEL
     }
@@ -1754,7 +1754,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous3[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Garret[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 45,
 	.species = SPECIES_AZUMARILL,
         .heldItem = ITEM_NUGGET
@@ -1763,7 +1763,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Garret[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Winston2[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_LINOONE,
         .heldItem = ITEM_NUGGET
@@ -1772,7 +1772,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Winston2[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Winston3[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_LINOONE,
         .heldItem = ITEM_NUGGET
@@ -1781,7 +1781,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Winston3[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Winston4[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_LINOONE,
         .heldItem = ITEM_NUGGET
@@ -1790,7 +1790,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Winston4[] = {
 
 const struct TrainerMonItemCustomMoves gTrainerParty_Winston5[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_LINOONE,
         .heldItem = ITEM_NUGGET,
@@ -1800,7 +1800,7 @@ const struct TrainerMonItemCustomMoves gTrainerParty_Winston5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Steve1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_ARON
     }
@@ -1808,7 +1808,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Steve1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Chris[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 23,
 	.species = SPECIES_LAIRON
     }
@@ -1816,7 +1816,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Chris[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Mark[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_LAIRON
     }
@@ -1824,7 +1824,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Mark[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kenn[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_LAIRON
     }
@@ -1832,7 +1832,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kenn[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Steve2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_LAIRON
     }
@@ -1840,12 +1840,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Steve2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Steve3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_LAIRON
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_RHYHORN
     }
@@ -1853,12 +1853,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Steve3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Steve4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_LAIRON
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_RHYHORN
     }
@@ -1866,12 +1866,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Steve4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Steve5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_AGGRON
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_RHYDON
     }
@@ -1879,7 +1879,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Steve5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Luis[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_CARVANHA
     }
@@ -1887,17 +1887,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Luis[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Austin[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_MAGIKARP
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_WINGULL
     }
@@ -1905,12 +1905,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Austin[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Douglas[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_TENTACOOL
     }
@@ -1918,7 +1918,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Douglas[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Darrin[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_TENTACOOL
     }
@@ -1926,7 +1926,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Darrin[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tony1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_CARVANHA
     }
@@ -1934,12 +1934,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tony1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jerome[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_WINGULL
     }
@@ -1947,7 +1947,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jerome[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Matthew[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_CARVANHA
     }
@@ -1955,12 +1955,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Matthew[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_David[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_CARVANHA
     }
@@ -1968,17 +1968,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_David[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Spencer[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_TENTACOOL
     }
@@ -1986,7 +1986,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Spencer[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Roland[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_CARVANHA
     }
@@ -1994,12 +1994,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Roland[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cody[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_STARYU
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_WINGULL
     }
@@ -2007,7 +2007,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cody[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Stan[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_HORSEA
     }
@@ -2015,7 +2015,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Stan[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Barry[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_GYARADOS
     }
@@ -2023,17 +2023,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Barry[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dean[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_CARVANHA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_CARVANHA
     }
@@ -2041,12 +2041,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dean[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Rodney[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_HORSEA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_GYARADOS
     }
@@ -2054,7 +2054,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Rodney[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Richard[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_PELIPPER
     }
@@ -2062,12 +2062,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Richard[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Herman[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_TENTACRUEL
     }
@@ -2075,7 +2075,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Herman[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous4[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_SHARPEDO
     }
@@ -2083,7 +2083,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Gilbert[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_SHARPEDO
     }
@@ -2091,12 +2091,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Gilbert[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Franklin[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_TENTACRUEL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SEALEO
     }
@@ -2104,12 +2104,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Franklin[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Danny[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_TENTACRUEL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_WAILMER
     }
@@ -2117,12 +2117,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Danny[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jack[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_STARYU
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_GYARADOS
     }
@@ -2130,17 +2130,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jack[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dudley[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_TENTACRUEL
     }
@@ -2148,12 +2148,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dudley[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Chad[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_WAILMER
     }
@@ -2161,7 +2161,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Chad[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tony2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_SHARPEDO
     }
@@ -2169,7 +2169,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tony2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tony3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_SHARPEDO
     }
@@ -2177,12 +2177,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tony3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tony4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_STARYU
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_SHARPEDO
     }
@@ -2190,12 +2190,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tony4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tony5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_STARMIE
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_SHARPEDO
     }
@@ -2203,7 +2203,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tony5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Hideki[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 14,
 	.species = SPECIES_MACHOP
     }
@@ -2211,12 +2211,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Hideki[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Hitoshi[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_MACHOKE
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_MACHOKE
     }
@@ -2224,17 +2224,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Hitoshi[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kiyo[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_MAKUHITA
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_MAKUHITA
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_MACHOKE
     }
@@ -2242,12 +2242,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kiyo[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Koichi[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_MACHOP
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_MACHOKE
     }
@@ -2255,7 +2255,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Koichi[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nob1[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_MACHOP
     }
@@ -2263,7 +2263,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nob1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nob2[] = {
     {
-	.iv = 110,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_MACHOKE
     }
@@ -2271,12 +2271,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nob2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nob3[] = {
     {
-	.iv = 120,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_MACHOP
     },
     {
-	.iv = 120,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_MACHOKE
     }
@@ -2284,17 +2284,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nob3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nob4[] = {
     {
-	.iv = 130,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_MACHOP
     },
     {
-	.iv = 130,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_MACHOKE
     },
     {
-	.iv = 130,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_MACHOKE
     }
@@ -2302,25 +2302,25 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nob4[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Nob5[] = {
     {
-	.iv = 140,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_MACHOP,
         .heldItem = ITEM_NONE
     },
     {
-	.iv = 140,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_MACHOKE,
         .heldItem = ITEM_NONE
     },
     {
-	.iv = 140,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_MACHOKE,
         .heldItem = ITEM_NONE
     },
     {
-	.iv = 140,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_MACHAMP,
         .heldItem = ITEM_BLACK_BELT
@@ -2329,12 +2329,12 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Nob5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Yuji[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_MAKUHITA
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_MACHOKE
     }
@@ -2342,7 +2342,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Yuji[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Daisuke[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_MACHOP
     }
@@ -2350,17 +2350,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Daisuke[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Atsushi[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_MAKUHITA
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_MACHOKE
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_HARIYAMA
     }
@@ -2368,12 +2368,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Atsushi[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kirk[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_ELECTRIKE
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_MAGNEMITE
     }
@@ -2381,7 +2381,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kirk[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Scott[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_ELECTRIKE
     }
@@ -2389,12 +2389,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Scott[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Harvey[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_MAGNEMITE
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_ELECTRIKE
     }
@@ -2402,17 +2402,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Harvey[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shawn[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_VOLTORB
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_VOLTORB
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_VOLTORB
     }
@@ -2420,17 +2420,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shawn[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Randy[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 13,
 	.species = SPECIES_ELECTRIKE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 13,
 	.species = SPECIES_ELECTRIKE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 13,
 	.species = SPECIES_ELECTRIKE
     }
@@ -2438,17 +2438,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Randy[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dalton1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_MAGNEMITE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_WHISMUR
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_MAGNEMITE
     }
@@ -2456,17 +2456,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dalton1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dalton2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_MAGNEMITE
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_WHISMUR
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_MAGNEMITE
     }
@@ -2474,17 +2474,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dalton2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dalton3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_MAGNEMITE
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_LOUDRED
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_MAGNEMITE
     }
@@ -2492,17 +2492,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dalton3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dalton4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_MAGNETON
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_LOUDRED
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_MAGNETON
     }
@@ -2510,17 +2510,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dalton4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dalton5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_MAGNETON
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_EXPLOUD
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_MAGNETON
     }
@@ -2528,17 +2528,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dalton5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cole[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_SLUGMA
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_SLUGMA
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_NUMEL
     }
@@ -2546,7 +2546,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cole[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Flint[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_SLUGMA
     }
@@ -2554,12 +2554,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Flint[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Axle[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 23,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 23,
 	.species = SPECIES_SLUGMA
     }
@@ -2567,7 +2567,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Axle[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jake[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_NUMEL
     }
@@ -2575,12 +2575,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jake[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Andy[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 23,
 	.species = SPECIES_SLUGMA
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 23,
 	.species = SPECIES_NUMEL
     }
@@ -2588,12 +2588,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Andy[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Bernie1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_SLUGMA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_WINGULL
     }
@@ -2601,12 +2601,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Bernie1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Bernie2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_SLUGMA
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_WINGULL
     }
@@ -2614,12 +2614,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Bernie2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Bernie3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_SLUGMA
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_PELIPPER
     }
@@ -2627,12 +2627,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Bernie3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Bernie4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_SLUGMA
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_PELIPPER
     }
@@ -2640,12 +2640,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Bernie4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Bernie5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_MAGCARGO
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_PELIPPER
     }
@@ -2653,7 +2653,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Bernie5[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Drew[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_SANDSHREW,
         .moves = MOVE_DIG, MOVE_SAND_ATTACK, MOVE_POISON_STING, MOVE_SLASH
@@ -2662,19 +2662,19 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Drew[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Cliff[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_BALTOY,
         .moves = MOVE_RAPID_SPIN, MOVE_MUD_SLAP, MOVE_PSYBEAM, MOVE_ROCK_TOMB
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_SANDSHREW,
         .moves = MOVE_POISON_STING, MOVE_SAND_ATTACK, MOVE_SCRATCH, MOVE_DIG
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_BALTOY,
         .moves = MOVE_RAPID_SPIN, MOVE_MUD_SLAP, MOVE_PSYBEAM, MOVE_ROCK_TOMB
@@ -2683,12 +2683,12 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Cliff[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Larry[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_ZIGZAGOON
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_NUZLEAF
     }
@@ -2696,12 +2696,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Larry[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shane[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_SANDSHREW
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_NUZLEAF
     }
@@ -2709,7 +2709,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shane[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Justin[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_KECLEON
     }
@@ -2717,12 +2717,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Justin[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ethan1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 21,
 	.species = SPECIES_ZIGZAGOON
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 21,
 	.species = SPECIES_TAILLOW
     }
@@ -2730,12 +2730,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ethan1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jeff[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_TAILLOW
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_KECLEON
     }
@@ -2743,7 +2743,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jeff[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Travis[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_SANDSHREW
     }
@@ -2751,12 +2751,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Travis[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ethan2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_ZIGZAGOON
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_TAILLOW
     }
@@ -2764,12 +2764,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ethan2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ethan3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_LINOONE
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_SWELLOW
     }
@@ -2777,17 +2777,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ethan3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ethan4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SANDSHREW
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_LINOONE
     }
@@ -2795,17 +2795,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ethan4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ethan5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SANDSLASH
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_LINOONE
     }
@@ -2813,7 +2813,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ethan5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brent[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_SURSKIT
     }
@@ -2821,17 +2821,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brent[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Donald[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_WURMPLE
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_SILCOON
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_BEAUTIFLY
     }
@@ -2839,17 +2839,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Donald[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Taylor[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_WURMPLE
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_CASCOON
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_DUSTOX
     }
@@ -2857,17 +2857,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Taylor[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brandon1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_SURSKIT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_SURSKIT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_SURSKIT
     }
@@ -2875,17 +2875,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brandon1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Derek[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_NINCADA
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_DUSTOX
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_BEAUTIFLY
     }
@@ -2893,17 +2893,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Derek[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brandon2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SURSKIT
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SURSKIT
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SURSKIT
     }
@@ -2911,17 +2911,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brandon2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brandon3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SURSKIT
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SURSKIT
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_MASQUERAIN
     }
@@ -2929,22 +2929,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brandon3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brandon4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_SURSKIT
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_WURMPLE
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_SURSKIT
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_MASQUERAIN
     }
@@ -2952,31 +2952,31 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brandon4[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Brandon5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_SURSKIT,
         .heldItem = ITEM_NONE
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_DUSTOX,
         .heldItem = ITEM_NONE
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_SURSKIT,
         .heldItem = ITEM_NONE
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_MASQUERAIN,
         .heldItem = ITEM_SILVER_POWDER
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_BEAUTIFLY,
         .heldItem = ITEM_NONE
@@ -2985,7 +2985,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Brandon5[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Edward[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_ABRA,
         .moves = MOVE_HIDDEN_POWER, MOVE_NONE, MOVE_NONE, MOVE_NONE
@@ -2994,7 +2994,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Edward[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Preston[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_KIRLIA
     }
@@ -3002,12 +3002,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Preston[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Virgil[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_RALTS
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_KADABRA
     }
@@ -3015,17 +3015,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Virgil[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Fritz[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_NATU
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_GIRAFARIG
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_KADABRA
     }
@@ -3033,12 +3033,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Fritz[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_William[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_RALTS
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_KIRLIA
     }
@@ -3046,12 +3046,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_William[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Joshua[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 41,
 	.species = SPECIES_KADABRA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 41,
 	.species = SPECIES_SOLROCK
     }
@@ -3059,12 +3059,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Joshua[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cameron1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_KADABRA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SOLROCK
     }
@@ -3072,12 +3072,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cameron1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cameron2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_KADABRA
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SOLROCK
     }
@@ -3085,12 +3085,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cameron2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cameron3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_KADABRA
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_SOLROCK
     }
@@ -3098,12 +3098,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cameron3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cameron4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_KADABRA
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_SOLROCK
     }
@@ -3111,12 +3111,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cameron4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cameron5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_SOLROCK
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_ALAKAZAM
     }
@@ -3124,7 +3124,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cameron5[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Jaclyn[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_ABRA,
         .moves = MOVE_HIDDEN_POWER, MOVE_NONE, MOVE_NONE, MOVE_NONE
@@ -3133,12 +3133,12 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Jaclyn[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Hannah[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_RALTS
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_KIRLIA
     }
@@ -3146,7 +3146,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Hannah[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Samantha[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_XATU
     }
@@ -3154,12 +3154,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Samantha[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Maura[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_KADABRA
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_KIRLIA
     }
@@ -3167,7 +3167,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Maura[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kayla[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_KADABRA
     }
@@ -3175,17 +3175,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kayla[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Alexis[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_KIRLIA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_XATU
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_KADABRA
     }
@@ -3193,12 +3193,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Alexis[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jacki1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_KADABRA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_LUNATONE
     }
@@ -3206,12 +3206,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jacki1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jacki2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_KADABRA
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_LUNATONE
     }
@@ -3219,12 +3219,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jacki2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jacki3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_KADABRA
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_LUNATONE
     }
@@ -3232,12 +3232,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jacki3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jacki4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_KADABRA
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_LUNATONE
     }
@@ -3245,12 +3245,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jacki4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jacki5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_LUNATONE
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_ALAKAZAM
     }
@@ -3258,7 +3258,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jacki5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Walter1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_MANECTRIC
     }
@@ -3266,12 +3266,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Walter1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tucker[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 44,
 	.species = SPECIES_MANECTRIC
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 44,
 	.species = SPECIES_MANECTRIC
     }
@@ -3279,7 +3279,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tucker[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Thomas[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 45,
 	.species = SPECIES_ZANGOOSE
     }
@@ -3287,7 +3287,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Thomas[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Walter2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_MANECTRIC
     }
@@ -3295,13 +3295,13 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Walter2[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Walter3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_LINOONE,
         .moves = MOVE_HEADBUTT, MOVE_SAND_ATTACK, MOVE_ODOR_SLEUTH, MOVE_FURY_SWIPES
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_MANECTRIC,
         .moves = MOVE_QUICK_ATTACK, MOVE_SPARK, MOVE_ODOR_SLEUTH, MOVE_ROAR
@@ -3310,13 +3310,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Walter3[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Walter4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_LINOONE,
         .moves = MOVE_HEADBUTT, MOVE_SAND_ATTACK, MOVE_ODOR_SLEUTH, MOVE_FURY_SWIPES
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_MANECTRIC,
         .moves = MOVE_QUICK_ATTACK, MOVE_SPARK, MOVE_ODOR_SLEUTH, MOVE_NONE
@@ -3325,19 +3325,19 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Walter4[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Walter5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 41,
 	.species = SPECIES_LINOONE,
         .moves = MOVE_HEADBUTT, MOVE_SAND_ATTACK, MOVE_ODOR_SLEUTH, MOVE_FURY_SWIPES
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 41,
 	.species = SPECIES_GOLDUCK,
         .moves = MOVE_FURY_SWIPES, MOVE_DISABLE, MOVE_CONFUSION, MOVE_PSYCH_UP
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 41,
 	.species = SPECIES_MANECTRIC,
         .moves = MOVE_QUICK_ATTACK, MOVE_SPARK, MOVE_ODOR_SLEUTH, MOVE_ROAR
@@ -3346,28 +3346,28 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Walter5[] = {
 
 const struct TrainerMonItemCustomMoves gTrainerParty_Sidney[] = {
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 46,
 	.species = SPECIES_MIGHTYENA,
         .heldItem = ITEM_NONE,
         .moves = MOVE_ROAR, MOVE_TAKE_DOWN, MOVE_SAND_ATTACK, MOVE_CRUNCH
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 48,
 	.species = SPECIES_SHIFTRY,
         .heldItem = ITEM_NONE,
         .moves = MOVE_FAKE_OUT, MOVE_DOUBLE_TEAM, MOVE_SWAGGER, MOVE_EXTRASENSORY
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 46,
 	.species = SPECIES_CACTURNE,
         .heldItem = ITEM_NONE,
         .moves = MOVE_LEECH_SEED, MOVE_FAINT_ATTACK, MOVE_NEEDLE_ARM, MOVE_COTTON_SPORE
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 48,
 	.species = SPECIES_SHARPEDO,
         .heldItem = ITEM_NONE,
@@ -3384,28 +3384,28 @@ const struct TrainerMonItemCustomMoves gTrainerParty_Sidney[] = {
 
 const struct TrainerMonItemCustomMoves gTrainerParty_Phoebe[] = {
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 48,
 	.species = SPECIES_DUSCLOPS,
         .heldItem = ITEM_NONE,
         .moves = MOVE_SHADOW_PUNCH, MOVE_CONFUSE_RAY, MOVE_CURSE, MOVE_FUTURE_SIGHT
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 49,
 	.species = SPECIES_BANETTE,
         .heldItem = ITEM_NONE,
         .moves = MOVE_SHADOW_BALL, MOVE_SPITE, MOVE_WILL_O_WISP, MOVE_FAINT_ATTACK
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 50,
 	.species = SPECIES_SABLEYE,
         .heldItem = ITEM_NONE,
         .moves = MOVE_SHADOW_BALL, MOVE_PSYCHIC, MOVE_ATTRACT, MOVE_FAINT_ATTACK
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 49,
 	.species = SPECIES_BANETTE,
         .heldItem = ITEM_NONE,
@@ -3422,28 +3422,28 @@ const struct TrainerMonItemCustomMoves gTrainerParty_Phoebe[] = {
 
 const struct TrainerMonItemCustomMoves gTrainerParty_Glacia[] = {
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 50,
 	.species = SPECIES_GLALIE,
         .heldItem = ITEM_NONE,
         .moves = MOVE_LIGHT_SCREEN, MOVE_CRUNCH, MOVE_HAIL, MOVE_ICE_BEAM
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 50,
 	.species = SPECIES_SEALEO,
         .heldItem = ITEM_NONE,
         .moves = MOVE_SURF, MOVE_BODY_SLAM, MOVE_HAIL, MOVE_ICE_BALL
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 52,
 	.species = SPECIES_SEALEO,
         .heldItem = ITEM_NONE,
         .moves = MOVE_ATTRACT, MOVE_DIVE, MOVE_HAIL, MOVE_BLIZZARD
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 52,
 	.species = SPECIES_GLALIE,
         .heldItem = ITEM_NONE,
@@ -3460,28 +3460,28 @@ const struct TrainerMonItemCustomMoves gTrainerParty_Glacia[] = {
 
 const struct TrainerMonItemCustomMoves gTrainerParty_Drake[] = {
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 52,
 	.species = SPECIES_SHELGON,
         .heldItem = ITEM_NONE,
         .moves = MOVE_ROCK_TOMB, MOVE_DRAGON_CLAW, MOVE_PROTECT, MOVE_CRUNCH
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 54,
 	.species = SPECIES_ALTARIA,
         .heldItem = ITEM_NONE,
         .moves = MOVE_TAKE_DOWN, MOVE_DRAGON_BREATH, MOVE_DRAGON_DANCE, MOVE_REFRESH
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 53,
 	.species = SPECIES_FLYGON,
         .heldItem = ITEM_NONE,
         .moves = MOVE_DIG, MOVE_DRAGON_BREATH, MOVE_FLY, MOVE_SANDSTORM
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 53,
 	.species = SPECIES_FLYGON,
         .heldItem = ITEM_NONE,
@@ -3498,13 +3498,13 @@ const struct TrainerMonItemCustomMoves gTrainerParty_Drake[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Roxanne[] = {
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 14,
 	.species = SPECIES_GEODUDE,
         .moves = MOVE_TACKLE, MOVE_DEFENSE_CURL, MOVE_ROCK_THROW, MOVE_ROCK_TOMB
     },
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_NOSEPASS,
         .moves = MOVE_TACKLE, MOVE_HARDEN, MOVE_ROCK_THROW, MOVE_ROCK_TOMB
@@ -3513,13 +3513,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Roxanne[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Brawly[] = {
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_MACHOP,
         .moves = MOVE_LEER, MOVE_KARATE_CHOP, MOVE_SEISMIC_TOSS, MOVE_BULK_UP
     },
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_MAKUHITA,
         .moves = MOVE_ARM_THRUST, MOVE_KNOCK_OFF, MOVE_SAND_ATTACK, MOVE_BULK_UP
@@ -3528,19 +3528,19 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Brawly[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Wattson[] = {
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_MAGNEMITE,
         .moves = MOVE_SUPERSONIC, MOVE_SONIC_BOOM, MOVE_THUNDER_SHOCK, MOVE_THUNDER_WAVE
     },
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_VOLTORB,
         .moves = MOVE_ROLLOUT, MOVE_SELF_DESTRUCT, MOVE_SPARK, MOVE_SONIC_BOOM
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 23,
 	.species = SPECIES_MAGNETON,
         .moves = MOVE_SUPERSONIC, MOVE_SONIC_BOOM, MOVE_SHOCK_WAVE, MOVE_THUNDER_WAVE
@@ -3549,19 +3549,19 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Wattson[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Flannery[] = {
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_SLUGMA,
         .moves = MOVE_OVERHEAT, MOVE_SMOG, MOVE_LIGHT_SCREEN, MOVE_SUNNY_DAY
     },
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_SLUGMA,
         .moves = MOVE_FLAMETHROWER, MOVE_ROCK_SLIDE, MOVE_LIGHT_SCREEN, MOVE_SUNNY_DAY
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_TORKOAL,
         .moves = MOVE_OVERHEAT, MOVE_BODY_SLAM, MOVE_FLAIL, MOVE_ATTRACT
@@ -3570,19 +3570,19 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Flannery[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Norman[] = {
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_SLAKING,
         .moves = MOVE_ENCORE, MOVE_FACADE, MOVE_YAWN, MOVE_FAINT_ATTACK
     },
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_VIGOROTH,
         .moves = MOVE_SLASH, MOVE_FAINT_ATTACK, MOVE_FACADE, MOVE_ENCORE
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SLAKING,
         .moves = MOVE_FOCUS_PUNCH, MOVE_SLACK_OFF, MOVE_FACADE, MOVE_FAINT_ATTACK
@@ -3591,25 +3591,25 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Norman[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Winona[] = {
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SWELLOW,
         .moves = MOVE_QUICK_ATTACK, MOVE_AERIAL_ACE, MOVE_DOUBLE_TEAM, MOVE_ENDEAVOR
     },
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_PELIPPER,
         .moves = MOVE_WATER_GUN, MOVE_SUPERSONIC, MOVE_PROTECT, MOVE_AERIAL_ACE
     },
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_SKARMORY,
         .moves = MOVE_SAND_ATTACK, MOVE_FURY_ATTACK, MOVE_STEEL_WING, MOVE_AERIAL_ACE
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_ALTARIA,
         .moves = MOVE_EARTHQUAKE, MOVE_DRAGON_BREATH, MOVE_DRAGON_DANCE, MOVE_AERIAL_ACE
@@ -3618,14 +3618,14 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Winona[] = {
 
 const struct TrainerMonItemCustomMoves gTrainerParty_TateAndLiza[] = {
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_LUNATONE,
         .heldItem = ITEM_NONE,
         .moves = MOVE_LIGHT_SCREEN, MOVE_PSYCHIC, MOVE_HYPNOSIS, MOVE_CALM_MIND
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_SOLROCK,
         .heldItem = ITEM_NONE,
@@ -3635,31 +3635,31 @@ const struct TrainerMonItemCustomMoves gTrainerParty_TateAndLiza[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Wallace[] = {
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_LUVDISC,
         .moves = MOVE_WATER_PULSE, MOVE_ATTRACT, MOVE_SWEET_KISS, MOVE_FLAIL
     },
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_WHISCASH,
         .moves = MOVE_RAIN_DANCE, MOVE_WATER_PULSE, MOVE_AMNESIA, MOVE_EARTHQUAKE
     },
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_SEALEO,
         .moves = MOVE_ENCORE, MOVE_BODY_SLAM, MOVE_AURORA_BEAM, MOVE_WATER_PULSE
     },
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_SEAKING,
         .moves = MOVE_WATER_PULSE, MOVE_RAIN_DANCE, MOVE_FURY_ATTACK, MOVE_HORN_DRILL
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_MILOTIC,
         .moves = MOVE_WATER_PULSE, MOVE_TWISTER, MOVE_RECOVER, MOVE_ICE_BEAM
@@ -3668,7 +3668,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Wallace[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jerry1[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 10,
 	.species = SPECIES_RALTS
     }
@@ -3676,7 +3676,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jerry1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ted[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_RALTS
     }
@@ -3684,17 +3684,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ted[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Paul[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_ODDISH
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_WINGULL
     }
@@ -3702,12 +3702,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Paul[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jerry2[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_RALTS
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_MEDITITE
     }
@@ -3715,12 +3715,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jerry2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jerry3[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_KIRLIA
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_MEDITITE
     }
@@ -3728,12 +3728,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jerry3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jerry4[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_KIRLIA
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_MEDICHAM
     }
@@ -3741,17 +3741,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jerry4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jerry5[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_KIRLIA
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_BANETTE
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_MEDICHAM
     }
@@ -3759,12 +3759,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jerry5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Karen1[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_WHISMUR
     }
@@ -3772,12 +3772,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Karen1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Georgia[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_BEAUTIFLY
     }
@@ -3785,12 +3785,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Georgia[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Karen2[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_WHISMUR
     }
@@ -3798,12 +3798,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Karen2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Karen3[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_LOUDRED
     }
@@ -3811,12 +3811,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Karen3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Karen4[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_BRELOOM
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_LOUDRED
     }
@@ -3824,12 +3824,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Karen4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Karen5[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_BRELOOM
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_EXPLOUD
     }
@@ -3837,13 +3837,13 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Karen5[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_KateAndJoy[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_SPINDA,
         .moves = MOVE_HYPNOSIS, MOVE_PSYBEAM, MOVE_DIZZY_PUNCH, MOVE_TEETER_DANCE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_SLAKING,
         .moves = MOVE_FOCUS_PUNCH, MOVE_YAWN, MOVE_SLACK_OFF, MOVE_FAINT_ATTACK
@@ -3852,13 +3852,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_KateAndJoy[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_AnnaAndMeg1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_ZIGZAGOON,
         .moves = MOVE_GROWL, MOVE_TAIL_WHIP, MOVE_HEADBUTT, MOVE_ODOR_SLEUTH
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_MAKUHITA,
         .moves = MOVE_TACKLE, MOVE_FOCUS_ENERGY, MOVE_ARM_THRUST, MOVE_NONE
@@ -3867,13 +3867,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_AnnaAndMeg1[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_AnnaAndMeg2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_ZIGZAGOON,
         .moves = MOVE_GROWL, MOVE_TAIL_WHIP, MOVE_HEADBUTT, MOVE_ODOR_SLEUTH
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_MAKUHITA,
         .moves = MOVE_TACKLE, MOVE_FOCUS_ENERGY, MOVE_ARM_THRUST, MOVE_NONE
@@ -3882,13 +3882,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_AnnaAndMeg2[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_AnnaAndMeg3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_ZIGZAGOON,
         .moves = MOVE_GROWL, MOVE_TAIL_WHIP, MOVE_HEADBUTT, MOVE_ODOR_SLEUTH
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_MAKUHITA,
         .moves = MOVE_TACKLE, MOVE_FOCUS_ENERGY, MOVE_ARM_THRUST, MOVE_NONE
@@ -3897,13 +3897,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_AnnaAndMeg3[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_AnnaAndMeg4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_LINOONE,
         .moves = MOVE_GROWL, MOVE_TAIL_WHIP, MOVE_HEADBUTT, MOVE_ODOR_SLEUTH
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_MAKUHITA,
         .moves = MOVE_TACKLE, MOVE_FOCUS_ENERGY, MOVE_ARM_THRUST, MOVE_NONE
@@ -3912,13 +3912,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_AnnaAndMeg4[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_AnnaAndMeg5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_LINOONE,
         .moves = MOVE_GROWL, MOVE_TAIL_WHIP, MOVE_HEADBUTT, MOVE_ODOR_SLEUTH
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_HARIYAMA,
         .moves = MOVE_TACKLE, MOVE_FOCUS_ENERGY, MOVE_ARM_THRUST, MOVE_NONE
@@ -3927,13 +3927,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_AnnaAndMeg5[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Victor[] = {
     {
-	.iv = 25,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_TAILLOW,
         .heldItem = ITEM_ORAN_BERRY
     },
     {
-	.iv = 25,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_ZIGZAGOON,
         .heldItem = ITEM_ORAN_BERRY
@@ -3942,7 +3942,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Victor[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Miguel1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_SKITTY,
         .heldItem = ITEM_ORAN_BERRY
@@ -3951,42 +3951,42 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Miguel1[] = {
 
 const struct TrainerMonItemCustomMoves gTrainerParty_Colton[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_SKITTY,
         .heldItem = ITEM_ORAN_BERRY,
         .moves = MOVE_ASSIST, MOVE_CHARM, MOVE_FAINT_ATTACK, MOVE_HEAL_BELL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_SKITTY,
         .heldItem = ITEM_ORAN_BERRY,
         .moves = MOVE_ASSIST, MOVE_CHARM, MOVE_FAINT_ATTACK, MOVE_HEAL_BELL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_SKITTY,
         .heldItem = ITEM_ORAN_BERRY,
         .moves = MOVE_ASSIST, MOVE_CHARM, MOVE_FAINT_ATTACK, MOVE_HEAL_BELL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_SKITTY,
         .heldItem = ITEM_ORAN_BERRY,
         .moves = MOVE_ASSIST, MOVE_CHARM, MOVE_FAINT_ATTACK, MOVE_HEAL_BELL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_SKITTY,
         .heldItem = ITEM_ORAN_BERRY,
         .moves = MOVE_ASSIST, MOVE_CHARM, MOVE_FAINT_ATTACK, MOVE_HEAL_BELL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_DELCATTY,
         .heldItem = ITEM_ORAN_BERRY,
@@ -3996,7 +3996,7 @@ const struct TrainerMonItemCustomMoves gTrainerParty_Colton[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Miguel2[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_SKITTY,
         .heldItem = ITEM_ORAN_BERRY
@@ -4005,7 +4005,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Miguel2[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Miguel3[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_SKITTY,
         .heldItem = ITEM_ORAN_BERRY
@@ -4014,7 +4014,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Miguel3[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Miguel4[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_DELCATTY,
         .heldItem = ITEM_ORAN_BERRY
@@ -4023,7 +4023,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Miguel4[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Miguel5[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_DELCATTY,
         .heldItem = ITEM_SITRUS_BERRY
@@ -4032,7 +4032,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Miguel5[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Victoria[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_ROSELIA,
         .heldItem = ITEM_ORAN_BERRY
@@ -4041,7 +4041,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Victoria[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Vanessa[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_PIKACHU,
         .heldItem = ITEM_ORAN_BERRY
@@ -4050,19 +4050,19 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Vanessa[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Marissa[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_AZURILL,
         .heldItem = ITEM_ORAN_BERRY
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_MARILL,
         .heldItem = ITEM_ORAN_BERRY
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_AZUMARILL,
         .heldItem = ITEM_ORAN_BERRY
@@ -4071,13 +4071,13 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Marissa[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Isabel1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_PLUSLE,
         .heldItem = ITEM_ORAN_BERRY
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_MINUN,
         .heldItem = ITEM_ORAN_BERRY
@@ -4086,13 +4086,13 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Isabel1[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Isabel2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_PLUSLE,
         .heldItem = ITEM_ORAN_BERRY
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_MINUN,
         .heldItem = ITEM_ORAN_BERRY
@@ -4101,13 +4101,13 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Isabel2[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Isabel3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_PLUSLE,
         .heldItem = ITEM_ORAN_BERRY
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_MINUN,
         .heldItem = ITEM_ORAN_BERRY
@@ -4116,13 +4116,13 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Isabel3[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Isabel4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_PLUSLE,
         .heldItem = ITEM_ORAN_BERRY
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_MINUN,
         .heldItem = ITEM_ORAN_BERRY
@@ -4131,13 +4131,13 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Isabel4[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Isabel5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_PLUSLE,
         .heldItem = ITEM_SITRUS_BERRY
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_MINUN,
         .heldItem = ITEM_SITRUS_BERRY
@@ -4146,7 +4146,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Isabel5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Timothy1[] = {
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_HARIYAMA
     }
@@ -4154,7 +4154,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Timothy1[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Timothy2[] = {
     {
-	.iv = 210,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_HARIYAMA,
         .moves = MOVE_ARM_THRUST, MOVE_KNOCK_OFF, MOVE_SAND_ATTACK, MOVE_DIG
@@ -4163,7 +4163,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Timothy2[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Timothy3[] = {
     {
-	.iv = 220,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_HARIYAMA,
         .moves = MOVE_ARM_THRUST, MOVE_KNOCK_OFF, MOVE_SAND_ATTACK, MOVE_DIG
@@ -4172,7 +4172,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Timothy3[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Timothy4[] = {
     {
-	.iv = 230,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_HARIYAMA,
         .moves = MOVE_ARM_THRUST, MOVE_BELLY_DRUM, MOVE_SAND_ATTACK, MOVE_DIG
@@ -4181,7 +4181,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Timothy4[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Timothy5[] = {
     {
-	.iv = 240,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_HARIYAMA,
         .moves = MOVE_ARM_THRUST, MOVE_BELLY_DRUM, MOVE_SAND_ATTACK, MOVE_DIG
@@ -4190,7 +4190,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Timothy5[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Vicky[] = {
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_MEDITITE,
         .moves = MOVE_HI_JUMP_KICK, MOVE_MEDITATE, MOVE_CONFUSION, MOVE_DETECT
@@ -4199,12 +4199,12 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Vicky[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shelby1[] = {
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_MEDITITE
     },
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_MAKUHITA
     }
@@ -4212,12 +4212,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shelby1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shelby2[] = {
     {
-	.iv = 210,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_MEDITITE
     },
     {
-	.iv = 210,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_MAKUHITA
     }
@@ -4225,12 +4225,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shelby2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shelby3[] = {
     {
-	.iv = 220,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_MEDICHAM
     },
     {
-	.iv = 220,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_HARIYAMA
     }
@@ -4238,12 +4238,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shelby3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shelby4[] = {
     {
-	.iv = 230,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_MEDICHAM
     },
     {
-	.iv = 230,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_HARIYAMA
     }
@@ -4251,12 +4251,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shelby4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shelby5[] = {
     {
-	.iv = 240,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_MEDICHAM
     },
     {
-	.iv = 240,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_HARIYAMA
     }
@@ -4264,7 +4264,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Shelby5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Calvin1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 5,
 	.species = SPECIES_ZIGZAGOON
     }
@@ -4272,12 +4272,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Calvin1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Billy[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 6,
 	.species = SPECIES_SEEDOT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 8,
 	.species = SPECIES_TAILLOW
     }
@@ -4285,19 +4285,19 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Billy[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Josh[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 10,
 	.species = SPECIES_GEODUDE,
         .moves = MOVE_TACKLE, MOVE_NONE, MOVE_NONE, MOVE_NONE
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 8,
 	.species = SPECIES_GEODUDE,
         .moves = MOVE_TACKLE, MOVE_NONE, MOVE_NONE, MOVE_NONE
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 6,
 	.species = SPECIES_GEODUDE,
         .moves = MOVE_TACKLE, MOVE_NONE, MOVE_NONE, MOVE_NONE
@@ -4306,7 +4306,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Josh[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tommy[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 11,
 	.species = SPECIES_GEODUDE
     }
@@ -4314,12 +4314,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tommy[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Joey[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 8,
 	.species = SPECIES_ZIGZAGOON
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 10,
 	.species = SPECIES_MACHOP
     }
@@ -4327,7 +4327,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Joey[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Ben[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_ZIGZAGOON,
         .moves = MOVE_HEADBUTT, MOVE_SAND_ATTACK, MOVE_GROWL, MOVE_THUNDERBOLT
@@ -4336,12 +4336,12 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Ben[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous5[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_NINCADA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_NINCADA
     }
@@ -4349,12 +4349,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kevin[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_NINCADA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_NINCADA
     }
@@ -4362,12 +4362,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kevin[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Neal[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_TRAPINCH
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_LINOONE
     }
@@ -4375,7 +4375,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Neal[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dillon[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_ARON
     }
@@ -4383,7 +4383,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dillon[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Calvin2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_LINOONE
     }
@@ -4391,12 +4391,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Calvin2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Calvin3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_LINOONE
     }
@@ -4404,12 +4404,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Calvin3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Calvin4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_LINOONE
     }
@@ -4417,17 +4417,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Calvin4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Calvin5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_VIGOROTH
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_LINOONE
     }
@@ -4435,12 +4435,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Calvin5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Eddie[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 14,
 	.species = SPECIES_ZIGZAGOON
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_ZIGZAGOON
     }
@@ -4448,12 +4448,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Eddie[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Allen[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 5,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 3,
 	.species = SPECIES_TAILLOW
     }
@@ -4461,17 +4461,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Allen[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Timmy[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_ARON
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 14,
 	.species = SPECIES_ELECTRIKE
     }
@@ -4524,17 +4524,17 @@ const struct TrainerMonItemCustomMoves gTrainerParty_Steven[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Andrew[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 5,
 	.species = SPECIES_MAGIKARP
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 10,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_MAGIKARP
     }
@@ -4542,17 +4542,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Andrew[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ivan[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 6,
 	.species = SPECIES_MAGIKARP
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 6,
 	.species = SPECIES_MAGIKARP
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 6,
 	.species = SPECIES_MAGIKARP
     }
@@ -4560,22 +4560,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ivan[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Claude[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_GOLDEEN
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_GOLDEEN
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_BARBOACH
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_GOLDEEN
     }
@@ -4583,17 +4583,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Claude[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Elliot1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 11,
 	.species = SPECIES_MAGIKARP
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 8,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 11,
 	.species = SPECIES_MAGIKARP
     }
@@ -4601,7 +4601,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Elliot1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ned[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_TENTACOOL
     }
@@ -4609,22 +4609,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ned[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dale[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_TENTACOOL
     }
@@ -4632,7 +4632,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dale[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nolan[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_BARBOACH
     }
@@ -4640,12 +4640,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nolan[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Barny[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_CARVANHA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_CARVANHA
     }
@@ -4653,7 +4653,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Barny[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Wade[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_CARVANHA
     }
@@ -4661,22 +4661,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Wade[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Carter[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 23,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_TENTACOOL
     }
@@ -4684,17 +4684,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Carter[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Elliot2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_GYARADOS
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_GYARADOS
     }
@@ -4702,22 +4702,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Elliot2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Elliot3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_GYARADOS
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_CARVANHA
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_GYARADOS
     }
@@ -4725,22 +4725,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Elliot3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Elliot4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_GYARADOS
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_CARVANHA
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_TENTACRUEL
     },
     {
-	.iv = 31,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_GYARADOS
     }
@@ -4748,22 +4748,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Elliot4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Elliot5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_GYARADOS
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_SHARPEDO
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_GYARADOS
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_TENTACRUEL
     }
@@ -4771,32 +4771,32 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Elliot5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ronald[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_GYARADOS
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_GYARADOS
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_GYARADOS
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_GYARADOS
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_GYARADOS
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_MAGIKARP
     }
@@ -4804,17 +4804,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ronald[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jacob[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 7,
 	.species = SPECIES_VOLTORB
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 7,
 	.species = SPECIES_VOLTORB
     },
     {
-	.iv = 160,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_MAGNEMITE
     }
@@ -4822,12 +4822,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jacob[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anthony[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_MAGNEMITE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_MAGNEMITE
     }
@@ -4835,7 +4835,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anthony[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Benjamin1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_MAGNEMITE
     }
@@ -4843,7 +4843,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Benjamin1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Benjamin2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_MAGNEMITE
     }
@@ -4851,7 +4851,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Benjamin2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Benjamin3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_MAGNEMITE
     }
@@ -4859,7 +4859,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Benjamin3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Benjamin4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_MAGNETON
     }
@@ -4867,7 +4867,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Benjamin4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Benjamin5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_MAGNETON
     }
@@ -4875,7 +4875,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Benjamin5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Abigail1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_MAGNEMITE
     }
@@ -4883,17 +4883,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Abigail1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jasmine[] = {
     {
-	.iv = 80,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_MAGNEMITE
     },
     {
-	.iv = 80,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_MAGNEMITE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 7,
 	.species = SPECIES_VOLTORB
     }
@@ -4901,7 +4901,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jasmine[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Abigail2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_MAGNEMITE
     }
@@ -4909,7 +4909,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Abigail2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Abigail3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_MAGNEMITE
     }
@@ -4917,7 +4917,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Abigail3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Abigail4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_MAGNETON
     }
@@ -4925,7 +4925,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Abigail4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Abigail5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_MAGNETON
     }
@@ -4933,7 +4933,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Abigail5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dylan1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_DODUO
     }
@@ -4941,7 +4941,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dylan1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dylan2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_DODUO
     }
@@ -4949,7 +4949,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dylan2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dylan3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_DODUO
     }
@@ -4957,7 +4957,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dylan3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dylan4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_DODRIO
     }
@@ -4965,7 +4965,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dylan4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dylan5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_DODRIO
     }
@@ -4973,7 +4973,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dylan5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Maria1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_DODUO
     }
@@ -4981,7 +4981,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Maria1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Maria2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_DODUO
     }
@@ -4989,7 +4989,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Maria2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Maria3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_DODUO
     }
@@ -4997,7 +4997,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Maria3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Maria4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_DODRIO
     }
@@ -5005,7 +5005,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Maria4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Maria5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_DODRIO
     }
@@ -5013,22 +5013,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Maria5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Caleb[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_STARYU
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_STARYU
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_STARYU
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_STARYU
     }
@@ -5036,7 +5036,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Caleb[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous6[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_STARYU
     }
@@ -5044,7 +5044,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous6[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaiah1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_STARYU
     }
@@ -5052,7 +5052,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaiah1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous7[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_STARYU
     }
@@ -5060,12 +5060,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous7[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Chase[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 80,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_STARYU
     }
@@ -5073,7 +5073,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Chase[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaiah2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_STARYU
     }
@@ -5081,7 +5081,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaiah2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaiah3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_STARYU
     }
@@ -5089,7 +5089,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaiah3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaiah4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 45,
 	.species = SPECIES_STARMIE
     }
@@ -5097,7 +5097,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaiah4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaiah5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 48,
 	.species = SPECIES_STARMIE
     }
@@ -5105,17 +5105,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaiah5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous8[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 160,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_STARYU
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_WINGULL
     }
@@ -5123,22 +5123,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous8[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Connor[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 160,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_STARYU
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 160,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_STARYU
     }
@@ -5146,7 +5146,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Connor[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous9[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_STARYU
     }
@@ -5154,7 +5154,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous9[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Katelyn1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_STARYU
     }
@@ -5162,22 +5162,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Katelyn1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Allison[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 240,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_STARYU
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_WINGULL
     }
@@ -5185,7 +5185,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Allison[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Katelyn2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_STARYU
     }
@@ -5193,7 +5193,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Katelyn2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Katelyn3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_STARYU
     }
@@ -5201,7 +5201,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Katelyn3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Katelyn4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 45,
 	.species = SPECIES_STARMIE
     }
@@ -5209,7 +5209,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Katelyn4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Katelyn5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 48,
 	.species = SPECIES_STARMIE
     }
@@ -5217,12 +5217,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Katelyn5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nicolas1[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_ALTARIA
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_ALTARIA
     }
@@ -5230,12 +5230,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nicolas1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nicolas2[] = {
     {
-	.iv = 110,
+	.iv = 255,
 	.level = 41,
 	.species = SPECIES_ALTARIA
     },
     {
-	.iv = 110,
+	.iv = 255,
 	.level = 41,
 	.species = SPECIES_ALTARIA
     }
@@ -5243,12 +5243,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nicolas2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nicolas3[] = {
     {
-	.iv = 120,
+	.iv = 255,
 	.level = 44,
 	.species = SPECIES_ALTARIA
     },
     {
-	.iv = 120,
+	.iv = 255,
 	.level = 44,
 	.species = SPECIES_ALTARIA
     }
@@ -5256,17 +5256,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nicolas3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nicolas4[] = {
     {
-	.iv = 130,
+	.iv = 255,
 	.level = 46,
 	.species = SPECIES_BAGON
     },
     {
-	.iv = 130,
+	.iv = 255,
 	.level = 46,
 	.species = SPECIES_ALTARIA
     },
     {
-	.iv = 130,
+	.iv = 255,
 	.level = 46,
 	.species = SPECIES_ALTARIA
     }
@@ -5274,19 +5274,19 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nicolas4[] = {
 
 const struct TrainerMonItemDefaultMoves gTrainerParty_Nicolas5[] = {
     {
-	.iv = 140,
+	.iv = 255,
 	.level = 49,
 	.species = SPECIES_ALTARIA,
         .heldItem = ITEM_NONE
     },
     {
-	.iv = 140,
+	.iv = 255,
 	.level = 49,
 	.species = SPECIES_ALTARIA,
         .heldItem = ITEM_NONE
     },
     {
-	.iv = 140,
+	.iv = 255,
 	.level = 49,
 	.species = SPECIES_SHELGON,
         .heldItem = ITEM_DRAGON_FANG
@@ -5295,7 +5295,7 @@ const struct TrainerMonItemDefaultMoves gTrainerParty_Nicolas5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Aaron[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_BAGON
     }
@@ -5303,7 +5303,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Aaron[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Perry[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_WINGULL
     }
@@ -5311,7 +5311,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Perry[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Hugh[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_SWELLOW
     }
@@ -5319,17 +5319,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Hugh[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Phil[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_TAILLOW
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_SWELLOW
     }
@@ -5337,7 +5337,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Phil[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jared[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_DODUO
     }
@@ -5345,22 +5345,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jared[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous10[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_TAILLOW
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_SWABLU
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_TAILLOW
     }
@@ -5368,17 +5368,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous10[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tanner[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_SWABLU
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_SWABLU
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_WINGULL
     }
@@ -5386,17 +5386,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tanner[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Will[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_PELIPPER
     }
@@ -5404,12 +5404,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Will[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Colin[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_NATU
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_SWELLOW
     }
@@ -5417,7 +5417,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Colin[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Robert1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_SWABLU
     }
@@ -5425,17 +5425,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Robert1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Benny[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_PELIPPER
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_XATU
     }
@@ -5443,12 +5443,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Benny[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Chester[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_TAILLOW
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_SWELLOW
     }
@@ -5456,12 +5456,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Chester[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Robert2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_NATU
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_SWABLU
     }
@@ -5469,12 +5469,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Robert2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Robert3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_NATU
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_ALTARIA
     }
@@ -5482,12 +5482,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Robert3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Robert4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_NATU
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_ALTARIA
     }
@@ -5495,12 +5495,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Robert4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Robert5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 41,
 	.species = SPECIES_ALTARIA
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 41,
 	.species = SPECIES_XATU
     }
@@ -5508,22 +5508,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Robert5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Alex[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_NATU
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_PELIPPER
     }
@@ -5531,12 +5531,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Alex[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Beck[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_PELIPPER
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_PELIPPER
     }
@@ -5544,7 +5544,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Beck[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Yasu[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_NINJASK
     }
@@ -5552,17 +5552,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Yasu[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Takashi[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_NINCADA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_KOFFING
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_NINJASK
     }
@@ -5570,7 +5570,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Takashi[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Makoto[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 23,
 	.species = SPECIES_NINJASK
     }
@@ -5578,22 +5578,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Makoto[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Hideo1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_NINJASK
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_SHEDINJA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_TRAPINCH
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_NINJASK
     }
@@ -5601,25 +5601,25 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Hideo1[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Lao1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_POISON_GAS, MOVE_TACKLE, MOVE_SMOG, MOVE_SELF_DESTRUCT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_POISON_GAS, MOVE_TACKLE, MOVE_SMOG, MOVE_NONE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_POISON_GAS, MOVE_TACKLE, MOVE_SMOG, MOVE_SELF_DESTRUCT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_TACKLE, MOVE_SMOG, MOVE_NONE, MOVE_NONE
@@ -5628,12 +5628,12 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Lao1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lung[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_NINCADA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_NINJASK
     }
@@ -5641,25 +5641,25 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lung[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Lao2[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_POISON_GAS, MOVE_TACKLE, MOVE_SLUDGE, MOVE_SELF_DESTRUCT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_POISON_GAS, MOVE_TACKLE, MOVE_SLUDGE, MOVE_NONE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_POISON_GAS, MOVE_TACKLE, MOVE_SLUDGE, MOVE_SELF_DESTRUCT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_TACKLE, MOVE_SLUDGE, MOVE_NONE, MOVE_NONE
@@ -5668,25 +5668,25 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Lao2[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Lao3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_POISON_GAS, MOVE_TACKLE, MOVE_SLUDGE, MOVE_SELF_DESTRUCT
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_POISON_GAS, MOVE_TACKLE, MOVE_SLUDGE, MOVE_SELF_DESTRUCT
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_POISON_GAS, MOVE_TACKLE, MOVE_SLUDGE, MOVE_NONE
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_TACKLE, MOVE_SLUDGE, MOVE_NONE, MOVE_NONE
@@ -5695,25 +5695,25 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Lao3[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Lao4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_POISON_GAS, MOVE_TACKLE, MOVE_SLUDGE, MOVE_NONE
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_POISON_GAS, MOVE_TACKLE, MOVE_SLUDGE, MOVE_NONE
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_POISON_GAS, MOVE_TACKLE, MOVE_SLUDGE, MOVE_NONE
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_TACKLE, MOVE_SLUDGE, MOVE_NONE, MOVE_NONE
@@ -5722,28 +5722,28 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Lao4[] = {
 
 const struct TrainerMonItemCustomMoves gTrainerParty_Lao5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_KOFFING,
         .heldItem = ITEM_NONE,
         .moves = MOVE_POISON_GAS, MOVE_TACKLE, MOVE_SLUDGE, MOVE_NONE
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_KOFFING,
         .heldItem = ITEM_NONE,
         .moves = MOVE_POISON_GAS, MOVE_TACKLE, MOVE_SLUDGE, MOVE_SELF_DESTRUCT
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_KOFFING,
         .heldItem = ITEM_NONE,
         .moves = MOVE_POISON_GAS, MOVE_TACKLE, MOVE_SLUDGE, MOVE_SELF_DESTRUCT
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_WEEZING,
         .heldItem = ITEM_SMOKE_BALL,
@@ -5753,17 +5753,17 @@ const struct TrainerMonItemCustomMoves gTrainerParty_Lao5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tessa[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_MEDITITE
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_MACHOP
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_MEDITITE
     }
@@ -5771,7 +5771,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tessa[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Laura[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 14,
 	.species = SPECIES_MEDITITE
     }
@@ -5779,12 +5779,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Laura[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cyndy1[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_MEDITITE
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_MAKUHITA
     }
@@ -5792,7 +5792,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cyndy1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cora[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_MEDITITE
     }
@@ -5800,7 +5800,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cora[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jill[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_BRELOOM
     }
@@ -5808,12 +5808,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jill[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cyndy2[] = {
     {
-	.iv = 110,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_MEDITITE
     },
     {
-	.iv = 110,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_MAKUHITA
     }
@@ -5821,12 +5821,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cyndy2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cyndy3[] = {
     {
-	.iv = 120,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_MEDITITE
     },
     {
-	.iv = 120,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_MAKUHITA
     }
@@ -5834,12 +5834,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cyndy3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cyndy4[] = {
     {
-	.iv = 130,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_MEDICHAM
     },
     {
-	.iv = 130,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_HARIYAMA
     }
@@ -5847,12 +5847,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cyndy4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cyndy5[] = {
     {
-	.iv = 140,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_MEDICHAM
     },
     {
-	.iv = 140,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_HARIYAMA
     }
@@ -5860,7 +5860,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Cyndy5[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Madeline1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_NUMEL,
         .moves = MOVE_EMBER, MOVE_TACKLE, MOVE_MAGNITUDE, MOVE_SUNNY_DAY
@@ -5869,12 +5869,12 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Madeline1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Clarissa[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_GOLDEEN
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_WAILMER
     }
@@ -5882,7 +5882,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Clarissa[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Angelica[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_CASTFORM
     }
@@ -5890,7 +5890,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Angelica[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Madeline2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_NUMEL,
         .moves = MOVE_EMBER, MOVE_TACKLE, MOVE_MAGNITUDE, MOVE_SUNNY_DAY
@@ -5899,7 +5899,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Madeline2[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Madeline3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_NUMEL,
         .moves = MOVE_EMBER, MOVE_TAKE_DOWN, MOVE_MAGNITUDE, MOVE_SUNNY_DAY
@@ -5908,13 +5908,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Madeline3[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Madeline4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_ROSELIA,
         .moves = MOVE_LEECH_SEED, MOVE_MEGA_DRAIN, MOVE_GRASS_WHISTLE, MOVE_SUNNY_DAY
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_NUMEL,
         .moves = MOVE_FLAMETHROWER, MOVE_TAKE_DOWN, MOVE_MAGNITUDE, MOVE_SUNNY_DAY
@@ -5923,13 +5923,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Madeline4[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Madeline5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_ROSELIA,
         .moves = MOVE_LEECH_SEED, MOVE_GIGA_DRAIN, MOVE_SOLAR_BEAM, MOVE_SUNNY_DAY
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_CAMERUPT,
         .moves = MOVE_FLAMETHROWER, MOVE_TAKE_DOWN, MOVE_EARTHQUAKE, MOVE_SUNNY_DAY
@@ -5938,12 +5938,12 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Madeline5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Beverly[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_WAILMER
     }
@@ -5951,7 +5951,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Beverly[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dawn[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_MARILL
     }
@@ -5959,7 +5959,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dawn[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nicole[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_WAILMER
     }
@@ -5967,7 +5967,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nicole[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Denise[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_WINGULL
     }
@@ -5975,17 +5975,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Denise[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Beth[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_MARILL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_GOLDEEN
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_WINGULL
     }
@@ -5993,12 +5993,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Beth[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tara[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_HORSEA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_MARILL
     }
@@ -6006,22 +6006,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tara[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Missy[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_GOLDEEN
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_MARILL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_WAILMER
     }
@@ -6029,17 +6029,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Missy[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Alice[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_GOLDEEN
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_GOLDEEN
     }
@@ -6047,7 +6047,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Alice[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jenny1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_WAILMER
     }
@@ -6055,17 +6055,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jenny1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grace[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_MARILL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_WINGULL
     }
@@ -6073,7 +6073,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grace[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tanya[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_LUVDISC
     }
@@ -6081,12 +6081,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tanya[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Sharon[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_GOLDEEN
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SEAKING
     }
@@ -6094,17 +6094,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Sharon[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nikki[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_MARILL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_SPHEAL
     }
@@ -6112,7 +6112,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nikki[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brenda[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_GOLDEEN
     }
@@ -6120,17 +6120,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brenda[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Katie[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_GOLDEEN
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_CHINCHOU
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_SPHEAL
     }
@@ -6138,17 +6138,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Katie[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Susie[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_HORSEA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_PELIPPER
     }
@@ -6156,7 +6156,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Susie[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kara[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_SEAKING
     }
@@ -6164,17 +6164,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kara[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dana[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_MARILL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_LUVDISC
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_AZUMARILL
     }
@@ -6182,7 +6182,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dana[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Erin[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_WAILMER
     }
@@ -6190,12 +6190,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Erin[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Debra[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_GOLDEEN
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SEAKING
     }
@@ -6203,12 +6203,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Debra[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Linda[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_HORSEA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SEADRA
     }
@@ -6216,12 +6216,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Linda[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kaylee[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_LANTURN
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_PELIPPER
     }
@@ -6229,17 +6229,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kaylee[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Laurel[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_LUVDISC
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_LUVDISC
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_LUVDISC
     }
@@ -6247,7 +6247,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Laurel[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Darcy[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 13,
 	.species = SPECIES_GOLDEEN
     }
@@ -6255,7 +6255,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Darcy[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jenny2[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_WAILMER
     }
@@ -6263,7 +6263,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jenny2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jenny3[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 41,
 	.species = SPECIES_WAILMER
     }
@@ -6271,12 +6271,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jenny3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jenny4[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_STARYU
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_WAILMER
     }
@@ -6284,17 +6284,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jenny4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jenny5[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 45,
 	.species = SPECIES_LUVDISC
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 45,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 45,
 	.species = SPECIES_STARMIE
     }
@@ -6302,13 +6302,13 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jenny5[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Heidi[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 23,
 	.species = SPECIES_SANDSHREW,
         .moves = MOVE_DIG, MOVE_SAND_ATTACK, MOVE_POISON_STING, MOVE_SLASH
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 23,
 	.species = SPECIES_BALTOY,
         .moves = MOVE_RAPID_SPIN, MOVE_MUD_SLAP, MOVE_PSYBEAM, MOVE_ROCK_TOMB
@@ -6317,7 +6317,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Heidi[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Becky[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_SANDSHREW,
         .moves = MOVE_SAND_ATTACK, MOVE_POISON_STING, MOVE_SLASH, MOVE_DIG
@@ -6326,12 +6326,12 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Becky[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Carol[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_TAILLOW
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_LOMBRE
     }
@@ -6339,12 +6339,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Carol[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nancy[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_MARILL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_LOMBRE
     }
@@ -6352,12 +6352,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nancy[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Martha[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 23,
 	.species = SPECIES_SKITTY
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 23,
 	.species = SPECIES_SWABLU
     }
@@ -6365,17 +6365,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Martha[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Diana1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_ODDISH
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_SWABLU
     }
@@ -6383,12 +6383,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Diana1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nina[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_SWABLU
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_ZIGZAGOON
     }
@@ -6396,12 +6396,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Nina[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Irene[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_MARILL
     }
@@ -6409,17 +6409,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Irene[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Diana2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_GLOOM
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_SWABLU
     }
@@ -6427,17 +6427,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Diana2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Diana3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_BRELOOM
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_GLOOM
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_SWABLU
     }
@@ -6445,17 +6445,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Diana3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Diana4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_BRELOOM
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_GLOOM
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SWABLU
     }
@@ -6463,17 +6463,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Diana4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Diana5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_BRELOOM
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_VILEPLUME
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_ALTARIA
     }
@@ -6481,12 +6481,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Diana5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_AmyAndLiv1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_PLUSLE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_MINUN
     }
@@ -6494,12 +6494,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_AmyAndLiv1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_AmyAndLiv2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_PLUSLE
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_MINUN
     }
@@ -6507,12 +6507,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_AmyAndLiv2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_GinaAndMia1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 8,
 	.species = SPECIES_LOTAD
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 8,
 	.species = SPECIES_SEEDOT
     }
@@ -6520,12 +6520,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_GinaAndMia1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_MiuAndYuki[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_BEAUTIFLY
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_DUSTOX
     }
@@ -6533,12 +6533,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_MiuAndYuki[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_AmyAndLiv3[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_PLUSLE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_MINUN
     }
@@ -6546,13 +6546,13 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_AmyAndLiv3[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_GinaAndMia2[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 10,
 	.species = SPECIES_DUSKULL,
         .moves = MOVE_NIGHT_SHADE, MOVE_DISABLE, MOVE_NONE, MOVE_NONE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 10,
 	.species = SPECIES_SHROOMISH,
         .moves = MOVE_ABSORB, MOVE_LEECH_SEED, MOVE_NONE, MOVE_NONE
@@ -6561,12 +6561,12 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_GinaAndMia2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_AmyAndLiv4[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_PLUSLE
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_MINUN
     }
@@ -6574,13 +6574,13 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_AmyAndLiv4[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_AmyAndLiv5[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_PLUSLE,
         .moves = MOVE_SPARK, MOVE_CHARGE, MOVE_FAKE_TEARS, MOVE_HELPING_HAND
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_MINUN,
         .moves = MOVE_SPARK, MOVE_CHARGE, MOVE_CHARM, MOVE_HELPING_HAND
@@ -6589,13 +6589,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_AmyAndLiv5[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_AmyAndLiv6[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_PLUSLE,
         .moves = MOVE_THUNDER, MOVE_CHARGE, MOVE_FAKE_TEARS, MOVE_HELPING_HAND
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_MINUN,
         .moves = MOVE_THUNDER, MOVE_CHARGE, MOVE_CHARM, MOVE_HELPING_HAND
@@ -6604,7 +6604,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_AmyAndLiv6[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Huey[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 14,
 	.species = SPECIES_MACHOP
     }
@@ -6612,17 +6612,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Huey[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Edmond[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_MACHOP
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_WINGULL
     }
@@ -6630,17 +6630,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Edmond[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ernest1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_MACHOKE
     }
@@ -6648,17 +6648,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ernest1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dwayne[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 11,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 11,
 	.species = SPECIES_MACHOP
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 11,
 	.species = SPECIES_TENTACOOL
     }
@@ -6666,12 +6666,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Dwayne[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Phillip[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 44,
 	.species = SPECIES_TENTACRUEL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 44,
 	.species = SPECIES_MACHOKE
     }
@@ -6679,17 +6679,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Phillip[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Leonard[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_MACHOP
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_PELIPPER
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_MACHOKE
     }
@@ -6697,12 +6697,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Leonard[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Duncan[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_MACHOKE
     }
@@ -6710,17 +6710,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Duncan[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ernest2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_MACHOKE
     }
@@ -6728,17 +6728,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ernest2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ernest3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_PELIPPER
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_MACHOKE
     }
@@ -6746,17 +6746,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ernest3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ernest4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_PELIPPER
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_MACHOKE
     }
@@ -6764,17 +6764,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ernest4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ernest5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 45,
 	.species = SPECIES_PELIPPER
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 45,
 	.species = SPECIES_MACHOKE
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 45,
 	.species = SPECIES_TENTACRUEL
     }
@@ -6782,12 +6782,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ernest5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous11[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_ROSELIA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_ROSELIA
     }
@@ -6795,17 +6795,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous11[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous12[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 21,
 	.species = SPECIES_ROSELIA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 21,
 	.species = SPECIES_ROSELIA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 21,
 	.species = SPECIES_ROSELIA
     }
@@ -6813,7 +6813,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous12[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous13[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 23,
 	.species = SPECIES_ROSELIA
     }
@@ -6821,7 +6821,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous13[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Sonny[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_SPHEAL
     }
@@ -6829,12 +6829,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Sonny[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Donovan[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SPHEAL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SPHEAL
     }
@@ -6842,17 +6842,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Donovan[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Gerald[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_SPHEAL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_SPHEAL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_SPHEAL
     }
@@ -6860,12 +6860,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Gerald[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kelvin[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SPHEAL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SPHEAL
     }
@@ -6873,17 +6873,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kelvin[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kody[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_SPHEAL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_SPHEAL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_SPHEAL
     }
@@ -6891,7 +6891,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kody[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tevin[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_SPHEAL
     }
@@ -6899,12 +6899,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tevin[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Damon[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SPHEAL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SPHEAL
     }
@@ -6912,7 +6912,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Damon[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Pablo[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_SPHEAL
     }
@@ -6920,12 +6920,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Pablo[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Edwin1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 14,
 	.species = SPECIES_LOMBRE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 14,
 	.species = SPECIES_NUZLEAF
     }
@@ -6933,7 +6933,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Edwin1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Hector1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_ZANGOOSE
     }
@@ -6941,7 +6941,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Hector1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Hector2[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_SEVIPER
     }
@@ -6949,12 +6949,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Hector2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Edwin2[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_LOMBRE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_NUZLEAF
     }
@@ -6962,12 +6962,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Edwin2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Edwin3[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_LOMBRE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_NUZLEAF
     }
@@ -6975,12 +6975,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Edwin3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Edwin4[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_LOMBRE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_NUZLEAF
     }
@@ -6988,12 +6988,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Edwin4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Edwin5[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_LUDICOLO
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_SHIFTRY
     }
@@ -7001,31 +7001,31 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Edwin5[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Wally1[] = {
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 44,
 	.species = SPECIES_ALTARIA,
         .moves = MOVE_AERIAL_ACE, MOVE_SAFEGUARD, MOVE_DRAGON_BREATH, MOVE_DRAGON_DANCE
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_DELCATTY,
         .moves = MOVE_SING, MOVE_ASSIST, MOVE_CHARM, MOVE_FAINT_ATTACK
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 44,
 	.species = SPECIES_ROSELIA,
         .moves = MOVE_MAGICAL_LEAF, MOVE_LEECH_SEED, MOVE_GIGA_DRAIN, MOVE_TOXIC
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 41,
 	.species = SPECIES_MAGNETON,
         .moves = MOVE_SUPERSONIC, MOVE_THUNDERBOLT, MOVE_TRI_ATTACK, MOVE_SCREECH
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 45,
 	.species = SPECIES_GARDEVOIR,
         .moves = MOVE_DOUBLE_TEAM, MOVE_CALM_MIND, MOVE_PSYCHIC, MOVE_FUTURE_SIGHT
@@ -7034,7 +7034,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Wally1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 5,
 	.species = SPECIES_TREECKO
     }
@@ -7042,17 +7042,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan2[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_GROVYLE
     }
@@ -7060,17 +7060,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan3[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_GROVYLE
     }
@@ -7078,7 +7078,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan4[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 5,
 	.species = SPECIES_TORCHIC
     }
@@ -7086,17 +7086,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan5[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_COMBUSKEN
     }
@@ -7104,17 +7104,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan6[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_COMBUSKEN
     }
@@ -7122,7 +7122,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan6[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan7[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 5,
 	.species = SPECIES_MUDKIP
     }
@@ -7130,17 +7130,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan7[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan8[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_MARSHTOMP
     }
@@ -7148,17 +7148,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan8[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan9[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_MARSHTOMP
     }
@@ -7166,7 +7166,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan9[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_May1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 5,
 	.species = SPECIES_TREECKO
     }
@@ -7174,17 +7174,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_May1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_May2[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_GROVYLE
     }
@@ -7192,17 +7192,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_May2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_May3[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_GROVYLE
     }
@@ -7210,7 +7210,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_May3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_May4[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 5,
 	.species = SPECIES_TORCHIC
     }
@@ -7218,17 +7218,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_May4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_May5[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_COMBUSKEN
     }
@@ -7236,17 +7236,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_May5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_May6[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_COMBUSKEN
     }
@@ -7254,7 +7254,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_May6[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_May7[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 5,
 	.species = SPECIES_MUDKIP
     }
@@ -7262,17 +7262,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_May7[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_May8[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_MARSHTOMP
     }
@@ -7280,17 +7280,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_May8[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_May9[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_MARSHTOMP
     }
@@ -7298,32 +7298,32 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_May9[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaac1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_WHISMUR
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_ZIGZAGOON
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_ARON
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_TAILLOW
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_MAKUHITA
     }
@@ -7331,17 +7331,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaac1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Riley[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_ZIGZAGOON
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_SPINDA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_POOCHYENA
     }
@@ -7349,12 +7349,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Riley[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Aidan[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 13,
 	.species = SPECIES_SEEDOT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 13,
 	.species = SPECIES_NUZLEAF
     }
@@ -7362,32 +7362,32 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Aidan[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaac2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_LOUDRED
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_LINOONE
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_ARON
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_MIGHTYENA
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_MAKUHITA
     }
@@ -7395,32 +7395,32 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaac2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaac3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_LOUDRED
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_LINOONE
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_ARON
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_MIGHTYENA
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_HARIYAMA
     }
@@ -7428,32 +7428,32 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaac3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaac4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_LOUDRED
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_LINOONE
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_ARON
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_MIGHTYENA
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_HARIYAMA
     }
@@ -7461,32 +7461,32 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaac4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaac5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_LOUDRED
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_LINOONE
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_LAIRON
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_MIGHTYENA
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_HARIYAMA
     }
@@ -7494,32 +7494,32 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Isaac5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lydia1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_MARILL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_ROSELIA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_SKITTY
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 12,
 	.species = SPECIES_GOLDEEN
     }
@@ -7527,12 +7527,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lydia1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Alexia[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 13,
 	.species = SPECIES_LOTAD
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 13,
 	.species = SPECIES_LOMBRE
     }
@@ -7540,7 +7540,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Alexia[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Danielle[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_SKITTY
     }
@@ -7548,32 +7548,32 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Danielle[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lydia2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_WINGULL
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_MARILL
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_ROSELIA
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_SKITTY
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_GOLDEEN
     }
@@ -7581,32 +7581,32 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lydia2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lydia3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_PELIPPER
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_BRELOOM
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_MARILL
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_ROSELIA
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_DELCATTY
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_GOLDEEN
     }
@@ -7614,32 +7614,32 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lydia3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lydia4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_PELIPPER
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_BRELOOM
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_MARILL
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_ROSELIA
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_DELCATTY
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_GOLDEEN
     }
@@ -7647,32 +7647,32 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lydia4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lydia5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_PELIPPER
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_BRELOOM
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_AZUMARILL
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_ROSELIA
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_DELCATTY
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SEAKING
     }
@@ -7680,7 +7680,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lydia5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jackson1[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_BRELOOM
     }
@@ -7688,17 +7688,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jackson1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Carlos[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_SEEDOT
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_NUZLEAF
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_LOMBRE
     }
@@ -7706,7 +7706,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Carlos[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Sebastian[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_CACTURNE
     }
@@ -7714,7 +7714,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Sebastian[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jackson2[] = {
     {
-	.iv = 60,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_BRELOOM
     }
@@ -7722,7 +7722,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jackson2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jackson3[] = {
     {
-	.iv = 70,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_BRELOOM
     }
@@ -7730,7 +7730,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jackson3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jackson4[] = {
     {
-	.iv = 80,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_BRELOOM
     }
@@ -7738,12 +7738,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jackson4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jackson5[] = {
     {
-	.iv = 90,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_KECLEON
     },
     {
-	.iv = 90,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_BRELOOM
     }
@@ -7751,12 +7751,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jackson5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Catherine1[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_GLOOM
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_ROSELIA
     }
@@ -7764,17 +7764,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Catherine1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jenna[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_LOTAD
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_LOMBRE
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_NUZLEAF
     }
@@ -7782,12 +7782,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jenna[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Sophia[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_SWABLU
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_ROSELIA
     }
@@ -7795,12 +7795,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Sophia[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Catherine2[] = {
     {
-	.iv = 60,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_GLOOM
     },
     {
-	.iv = 60,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_ROSELIA
     }
@@ -7808,12 +7808,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Catherine2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Catherine3[] = {
     {
-	.iv = 70,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_GLOOM
     },
     {
-	.iv = 70,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_ROSELIA
     }
@@ -7821,12 +7821,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Catherine3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Catherine4[] = {
     {
-	.iv = 80,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_GLOOM
     },
     {
-	.iv = 80,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_ROSELIA
     }
@@ -7834,12 +7834,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Catherine4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Catherine5[] = {
     {
-	.iv = 90,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_BELLOSSOM
     },
     {
-	.iv = 90,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_ROSELIA
     }
@@ -7847,12 +7847,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Catherine5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Maxie1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_TORKOAL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_CAMERUPT
     }
@@ -7860,12 +7860,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Maxie1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt28[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_POOCHYENA
     }
@@ -7873,22 +7873,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt28[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt29[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_ZUBAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_POOCHYENA
     }
@@ -7896,12 +7896,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt29[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt30[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_ZUBAT
     }
@@ -7909,7 +7909,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt30[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt31[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_NUMEL
     }
@@ -7917,12 +7917,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt31[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt32[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 37,
 	.species = SPECIES_NUMEL
     }
@@ -7930,7 +7930,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt32[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt33[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_NUMEL
     }
@@ -7938,17 +7938,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt33[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt34[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_ZUBAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_NUMEL
     }
@@ -7956,7 +7956,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt34[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt35[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_BALTOY
     }
@@ -7964,7 +7964,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt35[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt36[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_POOCHYENA
     }
@@ -7972,12 +7972,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt36[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt37[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_POOCHYENA
     }
@@ -7985,12 +7985,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt37[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt38[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_POOCHYENA
     }
@@ -7998,12 +7998,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt38[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt39[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_POOCHYENA
     }
@@ -8011,12 +8011,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt39[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt40[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_ZUBAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_POOCHYENA
     }
@@ -8024,12 +8024,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt40[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt41[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_ZUBAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_POOCHYENA
     }
@@ -8037,7 +8037,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt41[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt42[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 11,
 	.species = SPECIES_POOCHYENA
     }
@@ -8045,12 +8045,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt42[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt43[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_ZUBAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_POOCHYENA
     }
@@ -8058,12 +8058,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt43[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt44[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_NUMEL
     }
@@ -8071,17 +8071,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt44[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt45[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_ZUBAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_NUMEL
     }
@@ -8089,7 +8089,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt45[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt46[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_NUMEL
     }
@@ -8097,12 +8097,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt46[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt47[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 14,
 	.species = SPECIES_ZUBAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 14,
 	.species = SPECIES_NUMEL
     }
@@ -8110,7 +8110,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt47[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt48[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 17,
 	.species = SPECIES_BALTOY
     }
@@ -8118,17 +8118,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt48[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt49[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_ZUBAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_ZUBAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_ZUBAT
     }
@@ -8136,12 +8136,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt49[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt50[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_NUMEL
     }
@@ -8149,12 +8149,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt50[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt51[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_NUMEL
     }
@@ -8162,7 +8162,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt51[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt52[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_NUMEL
     }
@@ -8170,17 +8170,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt52[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt53[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_NUMEL
     }
@@ -8188,7 +8188,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt53[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt54[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_ZUBAT
     }
@@ -8196,12 +8196,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Grunt54[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous14[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_CARVANHA
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_MIGHTYENA
     }
@@ -8209,12 +8209,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous14[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous15[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_SWELLOW
     }
@@ -8222,17 +8222,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous15[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tabitha1[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_MIGHTYENA
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_CAMERUPT
     }
@@ -8240,17 +8240,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tabitha1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tabitha2[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_POOCHYENA
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_NUMEL
     }
@@ -8258,12 +8258,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tabitha2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous16[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 21,
 	.species = SPECIES_CARVANHA
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 21,
 	.species = SPECIES_SHARPEDO
     }
@@ -8271,12 +8271,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Anonymous16[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Courtney1[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_MIGHTYENA
     }
@@ -8284,12 +8284,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Courtney1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Courtney2[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_CAMERUPT
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 38,
 	.species = SPECIES_MIGHTYENA
     }
@@ -8297,17 +8297,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Courtney2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Maxie2[] = {
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 41,
 	.species = SPECIES_MIGHTYENA
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 41,
 	.species = SPECIES_CROBAT
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_CAMERUPT
     }
@@ -8315,17 +8315,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Maxie2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Maxie3[] = {
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_MIGHTYENA
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_GOLBAT
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_CAMERUPT
     }
@@ -8333,12 +8333,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Maxie3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tiana[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 4,
 	.species = SPECIES_ZIGZAGOON
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 4,
 	.species = SPECIES_ZIGZAGOON
     }
@@ -8346,12 +8346,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tiana[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Haley1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 7,
 	.species = SPECIES_LOTAD
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 7,
 	.species = SPECIES_SHROOMISH
     }
@@ -8359,7 +8359,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Haley1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Janice[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 10,
 	.species = SPECIES_MARILL
     }
@@ -8367,17 +8367,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Janice[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Vivi[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_MARILL
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_NUMEL
     }
@@ -8385,12 +8385,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Vivi[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Haley2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_LOMBRE
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_SHROOMISH
     }
@@ -8398,12 +8398,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Haley2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Haley3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_LOMBRE
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_BRELOOM
     }
@@ -8411,12 +8411,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Haley3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Haley4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_LOMBRE
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_BRELOOM
     }
@@ -8424,17 +8424,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Haley4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Haley5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_LOMBRE
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_BRELOOM
     }
@@ -8442,7 +8442,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Haley5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Sally[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_ODDISH
     }
@@ -8450,17 +8450,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Sally[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Robin[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 14,
 	.species = SPECIES_SKITTY
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 14,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 14,
 	.species = SPECIES_MARILL
     }
@@ -8468,7 +8468,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Robin[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Andrea[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 41,
 	.species = SPECIES_LUVDISC
     }
@@ -8476,12 +8476,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Andrea[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Crissy[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_WAILMER
     }
@@ -8489,12 +8489,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Crissy[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Rick[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 4,
 	.species = SPECIES_WURMPLE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 4,
 	.species = SPECIES_WURMPLE
     }
@@ -8502,32 +8502,32 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Rick[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lyle[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 3,
 	.species = SPECIES_WURMPLE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 3,
 	.species = SPECIES_WURMPLE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 3,
 	.species = SPECIES_WURMPLE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 3,
 	.species = SPECIES_WURMPLE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 3,
 	.species = SPECIES_WURMPLE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 3,
 	.species = SPECIES_WURMPLE
     }
@@ -8535,17 +8535,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lyle[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jose[] = {
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 8,
 	.species = SPECIES_WURMPLE
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 8,
 	.species = SPECIES_SILCOON
     },
     {
-	.iv = 50,
+	.iv = 255,
 	.level = 8,
 	.species = SPECIES_NINCADA
     }
@@ -8553,12 +8553,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jose[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Doug[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_NINCADA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_NINCADA
     }
@@ -8566,12 +8566,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Doug[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Greg[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_VOLBEAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_ILLUMISE
     }
@@ -8579,7 +8579,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Greg[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kent[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_NINJASK
     }
@@ -8587,7 +8587,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kent[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_James1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 8,
 	.species = SPECIES_NINCADA
     }
@@ -8595,7 +8595,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_James1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_James2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_NINJASK
     }
@@ -8603,12 +8603,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_James2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_James3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_DUSTOX
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_NINJASK
     }
@@ -8616,17 +8616,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_James3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_James4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SURSKIT
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_DUSTOX
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_NINJASK
     }
@@ -8634,22 +8634,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_James4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_James5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_SURSKIT
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_NINJASK
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_DUSTOX
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_NINJASK
     }
@@ -8657,12 +8657,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_James5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brice[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_MACHOP
     }
@@ -8670,22 +8670,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brice[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Trent1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_GEODUDE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_GEODUDE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_GEODUDE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_GEODUDE
     }
@@ -8693,12 +8693,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Trent1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lenny[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_MACHOP
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_MACHOP
     }
@@ -8706,17 +8706,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lenny[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lucas1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_GEODUDE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_GEODUDE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 18,
 	.species = SPECIES_GEODUDE
     }
@@ -8724,17 +8724,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Lucas1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Alan[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_GEODUDE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_NOSEPASS
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 22,
 	.species = SPECIES_GRAVELER
     }
@@ -8742,17 +8742,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Alan[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Clark[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 8,
 	.species = SPECIES_GEODUDE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 8,
 	.species = SPECIES_GEODUDE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 8,
 	.species = SPECIES_GEODUDE
     }
@@ -8760,12 +8760,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Clark[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Eric[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 21,
 	.species = SPECIES_BALTOY
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 21,
 	.species = SPECIES_BALTOY
     }
@@ -8773,7 +8773,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Eric[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Lucas2[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 9,
 	.species = SPECIES_WAILMER,
         .moves = MOVE_SPLASH, MOVE_WATER_GUN, MOVE_NONE, MOVE_NONE
@@ -8782,13 +8782,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Lucas2[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Mike1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 10,
 	.species = SPECIES_PELIPPER,
         .moves = MOVE_GUST, MOVE_GROWL, MOVE_NONE, MOVE_NONE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 10,
 	.species = SPECIES_POOCHYENA,
         .moves = MOVE_BITE, MOVE_SCARY_FACE, MOVE_NONE, MOVE_NONE
@@ -8797,17 +8797,17 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Mike1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Mike2[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_GEODUDE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_GEODUDE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_MACHOP
     }
@@ -8815,22 +8815,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Mike2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Trent2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_GEODUDE
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_GEODUDE
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_GEODUDE
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_GRAVELER
     }
@@ -8838,22 +8838,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Trent2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Trent3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_GEODUDE
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_GEODUDE
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_GRAVELER
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_GRAVELER
     }
@@ -8861,22 +8861,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Trent3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Trent4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_GEODUDE
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_GRAVELER
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_GRAVELER
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_GRAVELER
     }
@@ -8884,22 +8884,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Trent4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Trent5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_GRAVELER
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_GRAVELER
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_GRAVELER
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_GOLEM
     }
@@ -8907,12 +8907,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Trent5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_DezAndLuke[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_DELCATTY
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_MANECTRIC
     }
@@ -8920,12 +8920,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_DezAndLuke[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_LeaAndJed[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 45,
 	.species = SPECIES_LUVDISC
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 45,
 	.species = SPECIES_LUVDISC
     }
@@ -8933,12 +8933,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_LeaAndJed[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_LoisAndHal1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_VOLBEAT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_ILLUMISE
     }
@@ -8946,12 +8946,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_LoisAndHal1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_LoisAndHal2[] = {
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_VOLBEAT
     },
     {
-	.iv = 10,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_ILLUMISE
     }
@@ -8959,12 +8959,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_LoisAndHal2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_LoisAndHal3[] = {
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_VOLBEAT
     },
     {
-	.iv = 20,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_ILLUMISE
     }
@@ -8972,12 +8972,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_LoisAndHal3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_LoisAndHal4[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_VOLBEAT
     },
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_ILLUMISE
     }
@@ -8985,12 +8985,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_LoisAndHal4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_LoisAndHal5[] = {
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_VOLBEAT
     },
     {
-	.iv = 40,
+	.iv = 255,
 	.level = 39,
 	.species = SPECIES_ILLUMISE
     }
@@ -8998,7 +8998,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_LoisAndHal5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Johanna[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 13,
 	.species = SPECIES_GOLDEEN
     }
@@ -9006,7 +9006,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Johanna[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Zane[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_KECLEON,
         .moves = MOVE_FLAMETHROWER, MOVE_FURY_SWIPES, MOVE_FAINT_ATTACK, MOVE_BIND
@@ -9015,7 +9015,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Zane[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Vivian[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_MEDITITE,
         .moves = MOVE_BIDE, MOVE_DETECT, MOVE_CONFUSION, MOVE_THUNDER_PUNCH
@@ -9024,7 +9024,7 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Vivian[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Sadie[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_MEDITITE,
         .moves = MOVE_BIDE, MOVE_DETECT, MOVE_CONFUSION, MOVE_FIRE_PUNCH
@@ -9033,13 +9033,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Sadie[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Hideo2[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_TACKLE, MOVE_SELF_DESTRUCT, MOVE_SLUDGE, MOVE_SMOKESCREEN
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_TACKLE, MOVE_POISON_GAS, MOVE_SLUDGE, MOVE_SMOKESCREEN
@@ -9048,13 +9048,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Hideo2[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Keigo[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_POISON_GAS, MOVE_TACKLE, MOVE_SLUDGE, MOVE_SMOKESCREEN
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_NINJASK,
         .moves = MOVE_SAND_ATTACK, MOVE_DOUBLE_TEAM, MOVE_FURY_CUTTER, MOVE_SWORDS_DANCE
@@ -9063,19 +9063,19 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Keigo[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Tsunao[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_NINCADA,
         .moves = MOVE_LEECH_LIFE, MOVE_FURY_SWIPES, MOVE_MIND_READER, MOVE_DIG
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_KOFFING,
         .moves = MOVE_TACKLE, MOVE_SELF_DESTRUCT, MOVE_SLUDGE, MOVE_SMOKESCREEN
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_NINJASK,
         .moves = MOVE_DOUBLE_TEAM, MOVE_FURY_CUTTER, MOVE_SCREECH, MOVE_SWORDS_DANCE
@@ -9084,12 +9084,12 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Tsunao[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Terrell[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_TAILLOW
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 29,
 	.species = SPECIES_SWELLOW
     }
@@ -9097,7 +9097,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Terrell[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kylee[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_SWABLU
     }
@@ -9105,7 +9105,7 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Kylee[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Wally2[] = {
     {
-	.iv = 30,
+	.iv = 255,
 	.level = 16,
 	.species = SPECIES_RALTS
     }
@@ -9113,31 +9113,31 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Wally2[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Wally3[] = {
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 47,
 	.species = SPECIES_ALTARIA,
         .moves = MOVE_AERIAL_ACE, MOVE_SAFEGUARD, MOVE_DRAGON_BREATH, MOVE_DRAGON_DANCE
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 46,
 	.species = SPECIES_DELCATTY,
         .moves = MOVE_SING, MOVE_ASSIST, MOVE_CHARM, MOVE_FAINT_ATTACK
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 47,
 	.species = SPECIES_ROSELIA,
         .moves = MOVE_MAGICAL_LEAF, MOVE_LEECH_SEED, MOVE_GIGA_DRAIN, MOVE_TOXIC
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 44,
 	.species = SPECIES_MAGNETON,
         .moves = MOVE_SUPERSONIC, MOVE_THUNDERBOLT, MOVE_TRI_ATTACK, MOVE_SCREECH
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 48,
 	.species = SPECIES_GARDEVOIR,
         .moves = MOVE_DOUBLE_TEAM, MOVE_CALM_MIND, MOVE_PSYCHIC, MOVE_FUTURE_SIGHT
@@ -9146,31 +9146,31 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Wally3[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Wally4[] = {
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 50,
 	.species = SPECIES_ALTARIA,
         .moves = MOVE_AERIAL_ACE, MOVE_SAFEGUARD, MOVE_DRAGON_BREATH, MOVE_DRAGON_DANCE
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 49,
 	.species = SPECIES_DELCATTY,
         .moves = MOVE_SING, MOVE_ASSIST, MOVE_CHARM, MOVE_FAINT_ATTACK
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 50,
 	.species = SPECIES_ROSELIA,
         .moves = MOVE_MAGICAL_LEAF, MOVE_LEECH_SEED, MOVE_GIGA_DRAIN, MOVE_TOXIC
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 47,
 	.species = SPECIES_MAGNETON,
         .moves = MOVE_SUPERSONIC, MOVE_THUNDERBOLT, MOVE_TRI_ATTACK, MOVE_SCREECH
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 51,
 	.species = SPECIES_GARDEVOIR,
         .moves = MOVE_DOUBLE_TEAM, MOVE_CALM_MIND, MOVE_PSYCHIC, MOVE_FUTURE_SIGHT
@@ -9179,31 +9179,31 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Wally4[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Wally5[] = {
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 53,
 	.species = SPECIES_ALTARIA,
         .moves = MOVE_AERIAL_ACE, MOVE_SAFEGUARD, MOVE_DRAGON_BREATH, MOVE_DRAGON_DANCE
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 52,
 	.species = SPECIES_DELCATTY,
         .moves = MOVE_SING, MOVE_ASSIST, MOVE_CHARM, MOVE_FAINT_ATTACK
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 53,
 	.species = SPECIES_ROSELIA,
         .moves = MOVE_MAGICAL_LEAF, MOVE_LEECH_SEED, MOVE_GIGA_DRAIN, MOVE_TOXIC
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 50,
 	.species = SPECIES_MAGNETON,
         .moves = MOVE_SUPERSONIC, MOVE_THUNDERBOLT, MOVE_TRI_ATTACK, MOVE_SCREECH
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 54,
 	.species = SPECIES_GARDEVOIR,
         .moves = MOVE_DOUBLE_TEAM, MOVE_CALM_MIND, MOVE_PSYCHIC, MOVE_FUTURE_SIGHT
@@ -9212,31 +9212,31 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Wally5[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_Wally6[] = {
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 56,
 	.species = SPECIES_ALTARIA,
         .moves = MOVE_AERIAL_ACE, MOVE_SAFEGUARD, MOVE_DRAGON_BREATH, MOVE_DRAGON_DANCE
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 55,
 	.species = SPECIES_DELCATTY,
         .moves = MOVE_SING, MOVE_ASSIST, MOVE_CHARM, MOVE_FAINT_ATTACK
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 56,
 	.species = SPECIES_ROSELIA,
         .moves = MOVE_MAGICAL_LEAF, MOVE_LEECH_SEED, MOVE_GIGA_DRAIN, MOVE_TOXIC
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 53,
 	.species = SPECIES_MAGNETON,
         .moves = MOVE_SUPERSONIC, MOVE_THUNDERBOLT, MOVE_TRI_ATTACK, MOVE_SCREECH
     },
     {
-	.iv = 250,
+	.iv = 255,
 	.level = 57,
 	.species = SPECIES_GARDEVOIR,
         .moves = MOVE_DOUBLE_TEAM, MOVE_CALM_MIND, MOVE_PSYCHIC, MOVE_FUTURE_SIGHT
@@ -9245,22 +9245,22 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_Wally6[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan10[] = {
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_GROVYLE
     }
@@ -9268,22 +9268,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan10[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan11[] = {
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_COMBUSKEN
     }
@@ -9291,22 +9291,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan11[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan12[] = {
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_MARSHTOMP
     }
@@ -9314,22 +9314,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Brendan12[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_May10[] = {
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_GROVYLE
     }
@@ -9337,22 +9337,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_May10[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_May11[] = {
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_COMBUSKEN
     }
@@ -9360,22 +9360,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_May11[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_May12[] = {
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_SHROOMISH
     },
     {
-	.iv = 150,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_NUMEL
     },
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_MARSHTOMP
     }
@@ -9383,22 +9383,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_May12[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jonah[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_SHARPEDO
     }
@@ -9406,17 +9406,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Jonah[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Henry[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 31,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_CARVANHA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_TENTACRUEL
     }
@@ -9424,22 +9424,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Henry[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Roger[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 15,
 	.species = SPECIES_MAGIKARP
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 25,
 	.species = SPECIES_MAGIKARP
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_GYARADOS
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 45,
 	.species = SPECIES_MAGIKARP
     }
@@ -9447,12 +9447,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Roger[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Alexa[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_GLOOM
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_AZUMARILL
     }
@@ -9460,17 +9460,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Alexa[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ruben[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SHIFTRY
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_GRAVELER
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_LOUDRED
     }
@@ -9478,12 +9478,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Ruben[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Koji[] = {
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_MACHOKE
     },
     {
-	.iv = 100,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_MACHOKE
     }
@@ -9491,22 +9491,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Koji[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Wayne[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 35,
 	.species = SPECIES_WAILMER
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_TENTACRUEL
     }
@@ -9514,12 +9514,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Wayne[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Byron[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SWELLOW
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_PELIPPER
     }
@@ -9527,22 +9527,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Byron[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Reed[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_CARVANHA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_CARVANHA
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_SPHEAL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 32,
 	.species = SPECIES_SHARPEDO
     }
@@ -9550,17 +9550,17 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Reed[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tisha[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_CHINCHOU
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_LUVDISC
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 33,
 	.species = SPECIES_PELIPPER
     }
@@ -9568,12 +9568,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_Tisha[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_ToriAndTia[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_WHISMUR
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 20,
 	.species = SPECIES_WHISMUR
     }
@@ -9581,13 +9581,13 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_ToriAndTia[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_KimAndIris[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_SWABLU,
         .moves = MOVE_SING, MOVE_FURY_ATTACK, MOVE_SAFEGUARD, MOVE_AERIAL_ACE
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_NUMEL,
         .moves = MOVE_FLAMETHROWER, MOVE_TAKE_DOWN, MOVE_REST, MOVE_EARTHQUAKE
@@ -9596,13 +9596,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_KimAndIris[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_TyraAndIvy[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 19,
 	.species = SPECIES_ROSELIA,
         .moves = MOVE_GROWTH, MOVE_STUN_SPORE, MOVE_MEGA_DRAIN, MOVE_LEECH_SEED
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 21,
 	.species = SPECIES_GRAVELER,
         .moves = MOVE_DEFENSE_CURL, MOVE_ROLLOUT, MOVE_MUD_SPORT, MOVE_ROCK_THROW
@@ -9611,13 +9611,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_TyraAndIvy[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_MelAndPaul[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_DUSTOX,
         .moves = MOVE_GUST, MOVE_PSYBEAM, MOVE_TOXIC, MOVE_PROTECT
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_BEAUTIFLY,
         .moves = MOVE_GUST, MOVE_MEGA_DRAIN, MOVE_ATTRACT, MOVE_STUN_SPORE
@@ -9626,13 +9626,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_MelAndPaul[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_JohnAndJay1[] = {
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_MEDICHAM,
         .moves = MOVE_PSYCHIC, MOVE_FIRE_PUNCH, MOVE_PSYCH_UP, MOVE_PROTECT
     },
     {
-	.iv = 200,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_HARIYAMA,
         .moves = MOVE_FOCUS_PUNCH, MOVE_ROCK_TOMB, MOVE_REST, MOVE_BELLY_DRUM
@@ -9641,13 +9641,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_JohnAndJay1[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_JohnAndJay2[] = {
     {
-	.iv = 210,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_MEDICHAM,
         .moves = MOVE_PSYCHIC, MOVE_FIRE_PUNCH, MOVE_PSYCH_UP, MOVE_PROTECT
     },
     {
-	.iv = 210,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_HARIYAMA,
         .moves = MOVE_FOCUS_PUNCH, MOVE_ROCK_TOMB, MOVE_REST, MOVE_BELLY_DRUM
@@ -9656,13 +9656,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_JohnAndJay2[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_JohnAndJay3[] = {
     {
-	.iv = 220,
+	.iv = 255,
 	.level = 46,
 	.species = SPECIES_MEDICHAM,
         .moves = MOVE_PSYCHIC, MOVE_FIRE_PUNCH, MOVE_PSYCH_UP, MOVE_PROTECT
     },
     {
-	.iv = 220,
+	.iv = 255,
 	.level = 46,
 	.species = SPECIES_HARIYAMA,
         .moves = MOVE_FOCUS_PUNCH, MOVE_ROCK_TOMB, MOVE_REST, MOVE_BELLY_DRUM
@@ -9671,13 +9671,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_JohnAndJay3[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_JohnAndJay4[] = {
     {
-	.iv = 230,
+	.iv = 255,
 	.level = 49,
 	.species = SPECIES_MEDICHAM,
         .moves = MOVE_PSYCHIC, MOVE_FIRE_PUNCH, MOVE_PSYCH_UP, MOVE_PROTECT
     },
     {
-	.iv = 230,
+	.iv = 255,
 	.level = 49,
 	.species = SPECIES_HARIYAMA,
         .moves = MOVE_FOCUS_PUNCH, MOVE_ROCK_TOMB, MOVE_REST, MOVE_BELLY_DRUM
@@ -9686,13 +9686,13 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_JohnAndJay4[] = {
 
 const struct TrainerMonNoItemCustomMoves gTrainerParty_JohnAndJay5[] = {
     {
-	.iv = 240,
+	.iv = 255,
 	.level = 52,
 	.species = SPECIES_MEDICHAM,
         .moves = MOVE_PSYCHIC, MOVE_FIRE_PUNCH, MOVE_PSYCH_UP, MOVE_PROTECT
     },
     {
-	.iv = 240,
+	.iv = 255,
 	.level = 52,
 	.species = SPECIES_HARIYAMA,
         .moves = MOVE_FOCUS_PUNCH, MOVE_ROCK_TOMB, MOVE_REST, MOVE_BELLY_DRUM
@@ -9701,12 +9701,12 @@ const struct TrainerMonNoItemCustomMoves gTrainerParty_JohnAndJay5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_ReliAndIan[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_AZUMARILL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_WINGULL
     }
@@ -9714,12 +9714,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_ReliAndIan[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_RitaAndSam1[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 36,
 	.species = SPECIES_CHINCHOU
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 34,
 	.species = SPECIES_CARVANHA
     }
@@ -9727,12 +9727,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_RitaAndSam1[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_RitaAndSam2[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 42,
 	.species = SPECIES_CHINCHOU
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 40,
 	.species = SPECIES_CARVANHA
     }
@@ -9740,12 +9740,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_RitaAndSam2[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_RitaAndSam3[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 45,
 	.species = SPECIES_LANTURN
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 43,
 	.species = SPECIES_CARVANHA
     }
@@ -9753,12 +9753,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_RitaAndSam3[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_RitaAndSam4[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 48,
 	.species = SPECIES_LANTURN
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 46,
 	.species = SPECIES_SHARPEDO
     }
@@ -9766,12 +9766,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_RitaAndSam4[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_RitaAndSam5[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 51,
 	.species = SPECIES_LANTURN
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 49,
 	.species = SPECIES_SHARPEDO
     }
@@ -9779,12 +9779,12 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_RitaAndSam5[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_LisaAndRay[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 28,
 	.species = SPECIES_GOLDEEN
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 26,
 	.species = SPECIES_TENTACOOL
     }
@@ -9792,22 +9792,22 @@ const struct TrainerMonNoItemDefaultMoves gTrainerParty_LisaAndRay[] = {
 
 const struct TrainerMonNoItemDefaultMoves gTrainerParty_Eugene[] = {
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 30,
 	.species = SPECIES_MAGIKARP
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 21,
 	.species = SPECIES_TENTACOOL
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 27,
 	.species = SPECIES_FEEBAS
     },
     {
-	.iv = 0,
+	.iv = 255,
 	.level = 24,
 	.species = SPECIES_CARVANHA
     }

--- a/src/data/trainers_de.h
+++ b/src/data/trainers_de.h
@@ -8,7 +8,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x0,
+        .aiFlags = 0x7,
         .partySize = 0,
         .party = {.NoItemDefaultMoves = NULL }
     },
@@ -36,7 +36,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt1 }
     },
@@ -50,7 +50,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt2 }
     },
@@ -64,7 +64,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt3 }
     },
@@ -78,7 +78,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt4 }
     },
@@ -92,7 +92,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt5 }
     },
@@ -106,7 +106,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt6 }
     },
@@ -120,7 +120,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt7 }
     },
@@ -134,7 +134,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt8 }
     },
@@ -148,7 +148,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt9 }
     },
@@ -162,7 +162,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt10 }
     },
@@ -176,7 +176,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt11 }
     },
@@ -190,7 +190,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt12 }
     },
@@ -204,7 +204,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt13 }
     },
@@ -218,7 +218,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt14 }
     },
@@ -232,7 +232,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt15 }
     },
@@ -246,7 +246,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt16 }
     },
@@ -260,7 +260,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt17 }
     },
@@ -274,7 +274,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt18 }
     },
@@ -288,7 +288,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt19 }
     },
@@ -302,7 +302,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt20 }
     },
@@ -316,7 +316,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt21 }
     },
@@ -330,7 +330,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt22 }
     },
@@ -344,7 +344,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt23 }
     },
@@ -358,7 +358,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt24 }
     },
@@ -372,7 +372,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt25 }
     },
@@ -386,7 +386,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt26 }
     },
@@ -400,7 +400,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt27 }
     },
@@ -512,7 +512,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MARGARETE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Daisy }
     },
@@ -526,7 +526,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROSEMARIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Rose1 }
     },
@@ -540,7 +540,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LILLY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lily }
     },
@@ -554,7 +554,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ERIKA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Violet }
     },
@@ -568,7 +568,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROSEMARIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Rose2 }
     },
@@ -582,7 +582,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROSEMARIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Rose3 }
     },
@@ -596,7 +596,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROSEMARIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Rose4 }
     },
@@ -610,7 +610,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROSEMARIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Rose5 }
     },
@@ -624,7 +624,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜDIGER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Dusty1 }
     },
@@ -638,7 +638,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RUPRECHT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemCustomMoves = gTrainerParty_Chip }
     },
@@ -652,7 +652,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RUBEN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Foster }
     },
@@ -666,7 +666,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜDIGER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Dusty2 }
     },
@@ -680,7 +680,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜDIGER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Dusty3 }
     },
@@ -694,7 +694,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜDIGER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Dusty4 }
     },
@@ -708,7 +708,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜDIGER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Dusty5 }
     },
@@ -722,7 +722,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PIA & UDO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_GabbyAndTy1 }
     },
@@ -736,7 +736,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PIA & UDO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_GabbyAndTy2 }
     },
@@ -750,7 +750,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PIA & UDO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_GabbyAndTy3 }
     },
@@ -764,7 +764,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PIA & UDO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_GabbyAndTy4 }
     },
@@ -778,7 +778,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PIA & UDO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_GabbyAndTy5 }
     },
@@ -792,7 +792,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PIA & UDO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_GabbyAndTy6 }
     },
@@ -806,7 +806,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LOLA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lola1 }
     },
@@ -820,7 +820,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CARMEN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Carmen }
     },
@@ -834,7 +834,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HILDE "),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Gwen }
     },
@@ -848,7 +848,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LOLA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lola2 }
     },
@@ -862,7 +862,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LOLA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lola3 }
     },
@@ -876,7 +876,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LOLA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lola4 }
     },
@@ -890,7 +890,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LOLA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lola5 }
     },
@@ -904,7 +904,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GÜNTHER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Ricky1 }
     },
@@ -918,7 +918,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SIMON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Simon }
     },
@@ -932,7 +932,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HILMAR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Charlie }
     },
@@ -946,7 +946,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GÜNTHER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Ricky2 }
     },
@@ -960,7 +960,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GÜNTHER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Ricky3 }
     },
@@ -974,7 +974,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GÜNTHER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Ricky4 }
     },
@@ -988,7 +988,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GÜNTHER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Ricky5 }
     },
@@ -1478,7 +1478,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WALBURGA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Patricia }
     },
@@ -1492,7 +1492,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GUNDULA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kindra }
     },
@@ -1506,7 +1506,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BRUNHILDE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tammy }
     },
@@ -1520,7 +1520,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TABITHA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Valerie1 }
     },
@@ -1534,7 +1534,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PANDORA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tasha }
     },
@@ -1548,7 +1548,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TABITHA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Valerie2 }
     },
@@ -1562,7 +1562,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TABITHA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Valerie3 }
     },
@@ -1576,7 +1576,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TABITHA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Valerie4 }
     },
@@ -1590,7 +1590,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TABITHA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Valerie5 }
     },
@@ -1604,7 +1604,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PATRIZIA"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Cindy1 }
     },
@@ -1618,7 +1618,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous2 }
     },
@@ -1632,7 +1632,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NATASCHA"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Brianna1 }
     },
@@ -1646,7 +1646,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PATRIZIA"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Cindy2 }
     },
@@ -1660,7 +1660,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NATASCHA"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Brianna2 }
     },
@@ -1674,7 +1674,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANETTE"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Anette }
     },
@@ -1688,7 +1688,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PATRIZIA"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Cindy3 }
     },
@@ -1702,7 +1702,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PATRIZIA"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Cindy4 }
     },
@@ -1716,7 +1716,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PATRIZIA"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Cindy5 }
     },
@@ -1730,7 +1730,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PATRIZIA"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemCustomMoves = gTrainerParty_Cindy6 }
     },
@@ -1744,7 +1744,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MELISSA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Melissa }
     },
@@ -1758,7 +1758,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SYLVIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Sheila }
     },
@@ -1772,7 +1772,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MIRJAM"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Shirley }
     },
@@ -1786,7 +1786,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GERMAINE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Jessica1 }
     },
@@ -1800,7 +1800,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("FRANCESCA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Connie }
     },
@@ -1814,7 +1814,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SALMA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Bridget }
     },
@@ -1828,7 +1828,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Olivia }
     },
@@ -1842,7 +1842,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DANIELA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tiffany }
     },
@@ -1856,7 +1856,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GERMAINE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Jessica2 }
     },
@@ -1870,7 +1870,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GERMAINE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Jessica3 }
     },
@@ -1884,7 +1884,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GERMAINE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Jessica4 }
     },
@@ -1898,7 +1898,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GERMAINE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Jessica5 }
     },
@@ -1912,7 +1912,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RENE"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Winston1 }
     },
@@ -1926,7 +1926,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous3 }
     },
@@ -1940,7 +1940,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KAI"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Garret }
     },
@@ -1954,7 +1954,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RENE"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Winston2 }
     },
@@ -1968,7 +1968,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RENE"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Winston3 }
     },
@@ -1982,7 +1982,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RENE"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Winston4 }
     },
@@ -1996,7 +1996,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RENE"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemCustomMoves = gTrainerParty_Winston5 }
     },
@@ -2010,7 +2010,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HIRO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Steve1 }
     },
@@ -2024,7 +2024,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CHRIS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Chris }
     },
@@ -2038,7 +2038,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MARK"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Mark }
     },
@@ -2052,7 +2052,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KLAUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kenn }
     },
@@ -2066,7 +2066,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HIRO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Steve2 }
     },
@@ -2080,7 +2080,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HIRO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Steve3 }
     },
@@ -2094,7 +2094,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HIRO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Steve4 }
     },
@@ -2108,7 +2108,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HIRO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Steve5 }
     },
@@ -2122,7 +2122,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KONSTANTIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Luis }
     },
@@ -2136,7 +2136,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GUIDO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Austin }
     },
@@ -2150,7 +2150,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IGNAZ"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Douglas }
     },
@@ -2164,7 +2164,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MANUEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Darrin }
     },
@@ -2178,7 +2178,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KEVIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tony1 }
     },
@@ -2192,7 +2192,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("OSWALD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jerome }
     },
@@ -2206,7 +2206,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("UMBERTO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Matthew }
     },
@@ -2220,7 +2220,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WINFRIED"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_David }
     },
@@ -2234,7 +2234,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LEOPOLD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Spencer }
     },
@@ -2248,7 +2248,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("THOMAS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Roland }
     },
@@ -2262,7 +2262,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TIMO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cody }
     },
@@ -2276,7 +2276,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BALTHASAR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Stan }
     },
@@ -2290,7 +2290,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BASIL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Barry }
     },
@@ -2304,7 +2304,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DAGOBERT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dean }
     },
@@ -2318,7 +2318,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DIETER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Rodney }
     },
@@ -2332,7 +2332,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ENNO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Richard }
     },
@@ -2346,7 +2346,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BENNO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Herman }
     },
@@ -2360,7 +2360,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous4 }
     },
@@ -2374,7 +2374,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ERICH"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Gilbert }
     },
@@ -2388,7 +2388,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KASPER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Franklin }
     },
@@ -2402,7 +2402,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MARCEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Danny }
     },
@@ -2416,7 +2416,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PEDRO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jack }
     },
@@ -2430,7 +2430,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("THEODOR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dudley }
     },
@@ -2444,7 +2444,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JANNIK"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Chad }
     },
@@ -2458,7 +2458,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KEVIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tony2 }
     },
@@ -2472,7 +2472,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KEVIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tony3 }
     },
@@ -2486,7 +2486,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KEVIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tony4 }
     },
@@ -2500,7 +2500,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KEVIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tony5 }
     },
@@ -2514,7 +2514,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SATORU"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Hideki }
     },
@@ -2528,7 +2528,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SHIGERU"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Hitoshi }
     },
@@ -2542,7 +2542,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("YU"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kiyo }
     },
@@ -2556,7 +2556,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JUNICHI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Koichi }
     },
@@ -2570,7 +2570,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MINORU"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nob1 }
     },
@@ -2584,7 +2584,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MINORU"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nob2 }
     },
@@ -2598,7 +2598,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MINORU"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nob3 }
     },
@@ -2612,7 +2612,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MINORU"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nob4 }
     },
@@ -2626,7 +2626,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MINORU"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.ItemDefaultMoves = gTrainerParty_Nob5 }
     },
@@ -2640,7 +2640,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HIDEO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Yuji }
     },
@@ -2654,7 +2654,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KENJI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Daisuke }
     },
@@ -2668,7 +2668,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HIROSHI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Atsushi }
     },
@@ -2682,7 +2682,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CHUCK"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kirk }
     },
@@ -2696,7 +2696,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TREY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Scott }
     },
@@ -2710,7 +2710,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KERRY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Harvey }
     },
@@ -2724,7 +2724,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("REINHARD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Shawn }
     },
@@ -2738,7 +2738,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JEFF"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Randy }
     },
@@ -2752,7 +2752,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KIRK"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dalton1 }
     },
@@ -2766,7 +2766,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KIRK"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dalton2 }
     },
@@ -2780,7 +2780,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KIRK"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dalton3 }
     },
@@ -2794,7 +2794,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KIRK"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dalton4 }
     },
@@ -2808,7 +2808,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KIRK"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dalton5 }
     },
@@ -2822,7 +2822,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HENDRIK"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cole }
     },
@@ -2836,7 +2836,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HEINZ"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Flint }
     },
@@ -2850,7 +2850,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HAGEN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Axle }
     },
@@ -2864,7 +2864,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HANNES"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jake }
     },
@@ -2878,7 +2878,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HARTMANN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Andy }
     },
@@ -2892,7 +2892,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HASSO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Bernie1 }
     },
@@ -2906,7 +2906,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HASSO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Bernie2 }
     },
@@ -2920,7 +2920,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HASSO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Bernie3 }
     },
@@ -2934,7 +2934,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HASSO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Bernie4 }
     },
@@ -2948,7 +2948,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HASSO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Bernie5 }
     },
@@ -2962,7 +2962,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISSIDOR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Drew }
     },
@@ -2976,7 +2976,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IVAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemCustomMoves = gTrainerParty_Cliff }
     },
@@ -2990,7 +2990,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KAREL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Larry }
     },
@@ -3004,7 +3004,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KUNO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Shane }
     },
@@ -3018,7 +3018,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LAURENZ"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Justin }
     },
@@ -3032,7 +3032,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EWALD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ethan1 }
     },
@@ -3046,7 +3046,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RAPHAEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jeff }
     },
@@ -3060,7 +3060,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RONALD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Travis }
     },
@@ -3074,7 +3074,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EWALD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ethan2 }
     },
@@ -3088,7 +3088,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EWALD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ethan3 }
     },
@@ -3102,7 +3102,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EWALD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ethan4 }
     },
@@ -3116,7 +3116,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EWALD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ethan5 }
     },
@@ -3130,7 +3130,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROMEO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Brent }
     },
@@ -3144,7 +3144,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TILL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Donald }
     },
@@ -3158,7 +3158,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("URIEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Taylor }
     },
@@ -3172,7 +3172,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BRUNO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Brandon1 }
     },
@@ -3186,7 +3186,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BURKARD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Derek }
     },
@@ -3200,7 +3200,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BRUNO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Brandon2 }
     },
@@ -3214,7 +3214,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BRUNO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Brandon3 }
     },
@@ -3228,7 +3228,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BRUNO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Brandon4 }
     },
@@ -3242,7 +3242,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BRUNO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 5,
         .party = {.ItemDefaultMoves = gTrainerParty_Brandon5 }
     },
@@ -3256,7 +3256,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WENDELIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Edward }
     },
@@ -3270,7 +3270,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("URBAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Preston }
     },
@@ -3284,7 +3284,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ZOLTAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Virgil }
     },
@@ -3298,7 +3298,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("XAVER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Fritz }
     },
@@ -3312,7 +3312,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WULF"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_William }
     },
@@ -3326,7 +3326,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JONAS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Joshua }
     },
@@ -3340,7 +3340,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MAXIMILIAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cameron1 }
     },
@@ -3354,7 +3354,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MAXIMILIAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cameron2 }
     },
@@ -3368,7 +3368,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MAXIMILIAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cameron3 }
     },
@@ -3382,7 +3382,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MAXIMILIAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cameron4 }
     },
@@ -3396,7 +3396,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MAXIMILIAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cameron5 }
     },
@@ -3410,7 +3410,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("COSIMA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Jaclyn }
     },
@@ -3424,7 +3424,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HANNAH"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Hannah }
     },
@@ -3438,7 +3438,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SAMANTHA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Samantha }
     },
@@ -3452,7 +3452,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DOLORES"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Maura }
     },
@@ -3466,7 +3466,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CAMILLA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kayla }
     },
@@ -3480,7 +3480,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALEXIS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Alexis }
     },
@@ -3494,7 +3494,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KORNELIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jacki1 }
     },
@@ -3508,7 +3508,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KORNELIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jacki2 }
     },
@@ -3522,7 +3522,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KORNELIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jacki3 }
     },
@@ -3536,7 +3536,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KORNELIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jacki4 }
     },
@@ -3550,7 +3550,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KORNELIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jacki5 }
     },
@@ -3564,7 +3564,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ABRAHAM"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Walter1 }
     },
@@ -3578,7 +3578,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CLAUDIO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tucker }
     },
@@ -3592,7 +3592,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NIKOLAI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Thomas }
     },
@@ -3606,7 +3606,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ABRAHAM"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Walter2 }
     },
@@ -3620,7 +3620,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ABRAHAM"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Walter3 }
     },
@@ -3634,7 +3634,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ABRAHAM"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Walter4 }
     },
@@ -3648,7 +3648,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ABRAHAM"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemCustomMoves = gTrainerParty_Walter5 }
     },
@@ -3830,7 +3830,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ORLANDO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jerry1 }
     },
@@ -3844,7 +3844,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RAMON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ted }
     },
@@ -3858,7 +3858,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JÜRGEN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Paul }
     },
@@ -3872,7 +3872,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ORLANDO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jerry2 }
     },
@@ -3886,7 +3886,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ORLANDO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jerry3 }
     },
@@ -3900,7 +3900,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ORLANDO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jerry4 }
     },
@@ -3914,7 +3914,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ORLANDO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jerry5 }
     },
@@ -3928,7 +3928,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KERSTIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Karen1 }
     },
@@ -3942,7 +3942,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ARIANE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Georgia }
     },
@@ -3956,7 +3956,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KERSTIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Karen2 }
     },
@@ -3970,7 +3970,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KERSTIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Karen3 }
     },
@@ -3984,7 +3984,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KERSTIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Karen4 }
     },
@@ -3998,7 +3998,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KERSTIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Karen5 }
     },
@@ -4012,7 +4012,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EVA & UTE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_KateAndJoy }
     },
@@ -4026,7 +4026,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IRM & IDA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_AnnaAndMeg1 }
     },
@@ -4040,7 +4040,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IRM & IDA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_AnnaAndMeg2 }
     },
@@ -4054,7 +4054,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IRM & IDA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_AnnaAndMeg3 }
     },
@@ -4068,7 +4068,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IRM & IDA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_AnnaAndMeg4 }
     },
@@ -4082,7 +4082,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IRM & IDA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_AnnaAndMeg5 }
     },
@@ -4096,7 +4096,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("VIKTOR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.ItemDefaultMoves = gTrainerParty_Victor }
     },
@@ -4110,7 +4110,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MIGUEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Miguel1 }
     },
@@ -4124,7 +4124,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ATTILA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.ItemCustomMoves = gTrainerParty_Colton }
     },
@@ -4138,7 +4138,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MIGUEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Miguel2 }
     },
@@ -4152,7 +4152,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MIGUEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Miguel3 }
     },
@@ -4166,7 +4166,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MIGUEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Miguel4 }
     },
@@ -4180,7 +4180,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MIGUEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Miguel5 }
     },
@@ -4194,7 +4194,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("VIKTORIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x3,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Victoria }
     },
@@ -4208,7 +4208,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("VANESSA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Vanessa }
     },
@@ -4222,7 +4222,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EVELYN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.ItemDefaultMoves = gTrainerParty_Marissa }
     },
@@ -4236,7 +4236,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISABEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.ItemDefaultMoves = gTrainerParty_Isabel1 }
     },
@@ -4250,7 +4250,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISABEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.ItemDefaultMoves = gTrainerParty_Isabel2 }
     },
@@ -4264,7 +4264,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISABEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.ItemDefaultMoves = gTrainerParty_Isabel3 }
     },
@@ -4278,7 +4278,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISABEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.ItemDefaultMoves = gTrainerParty_Isabel4 }
     },
@@ -4292,7 +4292,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISABEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.ItemDefaultMoves = gTrainerParty_Isabel5 }
     },
@@ -4460,7 +4460,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANSGAR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Calvin1 }
     },
@@ -4474,7 +4474,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("FRIDOLIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Billy }
     },
@@ -4488,7 +4488,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GASTON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemCustomMoves = gTrainerParty_Josh }
     },
@@ -4502,7 +4502,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DOMINIK"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tommy }
     },
@@ -4516,7 +4516,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LUDGER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Joey }
     },
@@ -4530,7 +4530,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EGON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Ben }
     },
@@ -4544,7 +4544,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous5 }
     },
@@ -4558,7 +4558,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JULIUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kevin }
     },
@@ -4572,7 +4572,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MORITZ"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Neal }
     },
@@ -4586,7 +4586,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SÖNCKE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dillon }
     },
@@ -4600,7 +4600,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANSGAR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Calvin2 }
     },
@@ -4614,7 +4614,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANSGAR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Calvin3 }
     },
@@ -4628,7 +4628,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANSGAR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Calvin4 }
     },
@@ -4642,7 +4642,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANSGAR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Calvin5 }
     },
@@ -4656,7 +4656,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HENRY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Eddie }
     },
@@ -4670,7 +4670,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HUGO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Allen }
     },
@@ -4684,7 +4684,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("FRIEDER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Timmy }
     },
@@ -4712,7 +4712,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANSGAR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Andrew }
     },
@@ -4726,7 +4726,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANGELO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ivan }
     },
@@ -4740,7 +4740,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANSELM"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Claude }
     },
@@ -4754,7 +4754,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALOIS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Elliot1 }
     },
@@ -4768,7 +4768,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ARTHUR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ned }
     },
@@ -4782,7 +4782,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALBIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dale }
     },
@@ -4796,7 +4796,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("AMADEUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nolan }
     },
@@ -4810,7 +4810,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALBRECHT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Barny }
     },
@@ -4824,7 +4824,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALAIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Wade }
     },
@@ -4838,7 +4838,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ARMIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Carter }
     },
@@ -4852,7 +4852,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALOIS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Elliot2 }
     },
@@ -4866,7 +4866,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALOIS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Elliot3 }
     },
@@ -4880,7 +4880,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALOIS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Elliot4 }
     },
@@ -4894,7 +4894,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALOIS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x3,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Elliot5 }
     },
@@ -4908,7 +4908,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ACHMED"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ronald }
     },
@@ -4922,7 +4922,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROMAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jacob }
     },
@@ -4936,7 +4936,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EMIL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anthony }
     },
@@ -4950,7 +4950,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EGIDIUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Benjamin1 }
     },
@@ -4964,7 +4964,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EGIDIUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Benjamin2 }
     },
@@ -4978,7 +4978,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EGIDIUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Benjamin3 }
     },
@@ -4992,7 +4992,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EGIDIUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Benjamin4 }
     },
@@ -5006,7 +5006,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EGIDIUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Benjamin5 }
     },
@@ -5020,7 +5020,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IRMGARD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Abigail1 }
     },
@@ -5034,7 +5034,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MARTHA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jasmine }
     },
@@ -5048,7 +5048,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IRMGARD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Abigail2 }
     },
@@ -5062,7 +5062,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IRMGARD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Abigail3 }
     },
@@ -5076,7 +5076,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IRMGARD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Abigail4 }
     },
@@ -5090,7 +5090,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IRMGARD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Abigail5 }
     },
@@ -5104,7 +5104,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IGOR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dylan1 }
     },
@@ -5118,7 +5118,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IGOR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dylan2 }
     },
@@ -5132,7 +5132,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IGOR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dylan3 }
     },
@@ -5146,7 +5146,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IGOR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dylan4 }
     },
@@ -5160,7 +5160,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IGOR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dylan5 }
     },
@@ -5174,7 +5174,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JUTTA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Maria1 }
     },
@@ -5188,7 +5188,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JUTTA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Maria2 }
     },
@@ -5202,7 +5202,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JUTTA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Maria3 }
     },
@@ -5216,7 +5216,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JUTTA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Maria4 }
     },
@@ -5230,7 +5230,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JUTTA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Maria5 }
     },
@@ -5244,7 +5244,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("OLEG"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Caleb }
     },
@@ -5258,7 +5258,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous6 }
     },
@@ -5272,7 +5272,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KASPAR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaiah1 }
     },
@@ -5286,7 +5286,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous7 }
     },
@@ -5300,7 +5300,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("FERDINAND"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Chase }
     },
@@ -5314,7 +5314,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KASPAR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaiah2 }
     },
@@ -5328,7 +5328,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KASPAR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaiah3 }
     },
@@ -5342,7 +5342,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KASPAR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaiah4 }
     },
@@ -5356,7 +5356,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KASPAR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaiah5 }
     },
@@ -5370,7 +5370,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous8 }
     },
@@ -5384,7 +5384,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MIRA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Connor }
     },
@@ -5398,7 +5398,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous9 }
     },
@@ -5412,7 +5412,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MECHTHILD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Katelyn1 }
     },
@@ -5426,7 +5426,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LOTTE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Allison }
     },
@@ -5440,7 +5440,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MECHTHILD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Katelyn2 }
     },
@@ -5454,7 +5454,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MECHTHILD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Katelyn3 }
     },
@@ -5468,7 +5468,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MECHTHILD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Katelyn4 }
     },
@@ -5482,7 +5482,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MECHTHILD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Katelyn5 }
     },
@@ -5496,7 +5496,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALFONS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nicolas1 }
     },
@@ -5510,7 +5510,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALFONS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nicolas2 }
     },
@@ -5524,7 +5524,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALFONS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nicolas3 }
     },
@@ -5538,7 +5538,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALFONS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nicolas4 }
     },
@@ -5552,7 +5552,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALFONS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.ItemDefaultMoves = gTrainerParty_Nicolas5 }
     },
@@ -5566,7 +5566,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EDMUND"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Aaron }
     },
@@ -5580,7 +5580,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JOSCHKA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Perry }
     },
@@ -5594,7 +5594,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ENRICO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Hugh }
     },
@@ -5608,7 +5608,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HENRY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Phil }
     },
@@ -5622,7 +5622,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HIOB"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jared }
     },
@@ -5636,7 +5636,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous10 }
     },
@@ -5650,7 +5650,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANATOL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tanner }
     },
@@ -5664,7 +5664,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BJÖRN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Will }
     },
@@ -5678,7 +5678,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WIM"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Colin }
     },
@@ -5692,7 +5692,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("FRITJOF"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Robert1 }
     },
@@ -5706,7 +5706,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GENADI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Benny }
     },
@@ -5720,7 +5720,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("VITALI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Chester }
     },
@@ -5734,7 +5734,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("FRITJOF"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Robert2 }
     },
@@ -5748,7 +5748,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("FRITJOF"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Robert3 }
     },
@@ -5762,7 +5762,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("FRITJOF"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Robert4 }
     },
@@ -5776,7 +5776,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("FRITJOF"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Robert5 }
     },
@@ -5790,7 +5790,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ARNE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Alex }
     },
@@ -5804,7 +5804,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("VINCENT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Beck }
     },
@@ -5818,7 +5818,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("VALENTIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x3,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Yasu }
     },
@@ -5832,7 +5832,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EUGEN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x3,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Takashi }
     },
@@ -5846,7 +5846,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HERIBERT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x0,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Makoto }
     },
@@ -5860,7 +5860,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SAUL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x0,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Hideo1 }
     },
@@ -5874,7 +5874,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EDUARD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x0,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemCustomMoves = gTrainerParty_Lao1 }
     },
@@ -5888,7 +5888,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ARND"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x0,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lung }
     },
@@ -5902,7 +5902,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EDUARD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x0,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemCustomMoves = gTrainerParty_Lao2 }
     },
@@ -5916,7 +5916,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EDUARD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x0,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemCustomMoves = gTrainerParty_Lao3 }
     },
@@ -5930,7 +5930,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EDUARD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x0,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemCustomMoves = gTrainerParty_Lao4 }
     },
@@ -5944,7 +5944,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EDUARD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x0,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.ItemCustomMoves = gTrainerParty_Lao5 }
     },
@@ -5958,7 +5958,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TAMARA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tessa }
     },
@@ -5972,7 +5972,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LAURA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Laura }
     },
@@ -5986,7 +5986,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELFI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cyndy1 }
     },
@@ -6000,7 +6000,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("THEA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cora }
     },
@@ -6014,7 +6014,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("AGNES"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jill }
     },
@@ -6028,7 +6028,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELFI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cyndy2 }
     },
@@ -6042,7 +6042,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELFI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cyndy3 }
     },
@@ -6056,7 +6056,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELFI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cyndy4 }
     },
@@ -6070,7 +6070,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELFI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cyndy5 }
     },
@@ -6084,7 +6084,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SASKIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Madeline1 }
     },
@@ -6098,7 +6098,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GERDA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Clarissa }
     },
@@ -6112,7 +6112,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MARIKA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Angelica }
     },
@@ -6126,7 +6126,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SASKIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Madeline2 }
     },
@@ -6140,7 +6140,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SASKIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Madeline3 }
     },
@@ -6154,7 +6154,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SASKIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Madeline4 }
     },
@@ -6168,7 +6168,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SASKIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Madeline5 }
     },
@@ -6182,7 +6182,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DAGMAR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Beverly }
     },
@@ -6196,7 +6196,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HEIDRUN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dawn }
     },
@@ -6210,7 +6210,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NICOLE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nicole }
     },
@@ -6224,7 +6224,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DENISE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Denise }
     },
@@ -6238,7 +6238,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALMUT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Beth }
     },
@@ -6252,7 +6252,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SIEGLINDE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tara }
     },
@@ -6266,7 +6266,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MARION"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Missy }
     },
@@ -6280,7 +6280,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALICE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Alice }
     },
@@ -6294,7 +6294,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MONIKA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jenny1 }
     },
@@ -6308,7 +6308,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ILONA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grace }
     },
@@ -6322,7 +6322,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EMILIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tanya }
     },
@@ -6336,7 +6336,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GUDRUN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Sharon }
     },
@@ -6350,7 +6350,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ASTRID"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nikki }
     },
@@ -6364,7 +6364,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("OTTILIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Brenda }
     },
@@ -6378,7 +6378,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SENTA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Katie }
     },
@@ -6392,7 +6392,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JANKA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Susie }
     },
@@ -6406,7 +6406,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RENATE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kara }
     },
@@ -6420,7 +6420,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("VICKI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dana }
     },
@@ -6434,7 +6434,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("REBECCA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Erin }
     },
@@ -6448,7 +6448,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANJA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Debra }
     },
@@ -6462,7 +6462,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GISELA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Linda }
     },
@@ -6476,7 +6476,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PAOLA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kaylee }
     },
@@ -6490,7 +6490,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BIRTE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Laurel }
     },
@@ -6504,7 +6504,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DOROTHEA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Darcy }
     },
@@ -6518,7 +6518,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MONIKA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jenny2 }
     },
@@ -6532,7 +6532,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MONIKA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jenny3 }
     },
@@ -6546,7 +6546,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MONIKA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jenny4 }
     },
@@ -6560,7 +6560,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MONIKA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jenny5 }
     },
@@ -6574,7 +6574,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JANA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Heidi }
     },
@@ -6588,7 +6588,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HEIDI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Becky }
     },
@@ -6602,7 +6602,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NATALIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Carol }
     },
@@ -6616,7 +6616,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NANCY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nancy }
     },
@@ -6630,7 +6630,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MARTHA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Martha }
     },
@@ -6644,7 +6644,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GWENDOLIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Diana1 }
     },
@@ -6658,7 +6658,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NADJA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nina }
     },
@@ -6672,7 +6672,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IRENE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Irene }
     },
@@ -6686,7 +6686,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GWENDOLIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Diana2 }
     },
@@ -6700,7 +6700,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GWENDOLIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Diana3 }
     },
@@ -6714,7 +6714,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GWENDOLIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Diana4 }
     },
@@ -6728,7 +6728,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GWENDOLIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Diana5 }
     },
@@ -6742,7 +6742,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NORA & JO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_AmyAndLiv1 }
     },
@@ -6756,7 +6756,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NORA & JO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_AmyAndLiv2 }
     },
@@ -6770,7 +6770,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GINA & MIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_GinaAndMia1 }
     },
@@ -6784,7 +6784,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LEA & GRIT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_MiuAndYuki }
     },
@@ -6798,7 +6798,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NORA & JO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_AmyAndLiv3 }
     },
@@ -6812,7 +6812,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GINA & MIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_GinaAndMia2 }
     },
@@ -6826,7 +6826,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NORA & JO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_AmyAndLiv4 }
     },
@@ -6840,7 +6840,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NORA & JO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_AmyAndLiv5 }
     },
@@ -6854,7 +6854,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NORA & JO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_AmyAndLiv6 }
     },
@@ -6868,7 +6868,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TASSILO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Huey }
     },
@@ -6882,7 +6882,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MONTY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Edmond }
     },
@@ -6896,7 +6896,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELERT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ernest1 }
     },
@@ -6910,7 +6910,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RETO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dwayne }
     },
@@ -6924,7 +6924,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GUNNAR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Phillip }
     },
@@ -6938,7 +6938,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LEONARD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Leonard }
     },
@@ -6952,7 +6952,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PIERRE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Duncan }
     },
@@ -6966,7 +6966,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELERT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ernest2 }
     },
@@ -6980,7 +6980,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELERT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ernest3 }
     },
@@ -6994,7 +6994,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELERT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ernest4 }
     },
@@ -7008,7 +7008,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELERT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ernest5 }
     },
@@ -7022,7 +7022,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous11 }
     },
@@ -7036,7 +7036,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous12 }
     },
@@ -7050,7 +7050,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous13 }
     },
@@ -7064,7 +7064,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WENZEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Sonny }
     },
@@ -7078,7 +7078,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("STANISLAUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Donovan }
     },
@@ -7092,7 +7092,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GERALD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Gerald }
     },
@@ -7106,7 +7106,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("AARON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kelvin }
     },
@@ -7120,7 +7120,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALBERT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kody }
     },
@@ -7134,7 +7134,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANDRE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tevin }
     },
@@ -7148,7 +7148,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("AMON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Damon }
     },
@@ -7162,7 +7162,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PABLO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Pablo }
     },
@@ -7176,7 +7176,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EDWIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Edwin1 }
     },
@@ -7190,7 +7190,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HEKTOR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Hector1 }
     },
@@ -7204,7 +7204,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HEKTOR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Hector2 }
     },
@@ -7218,7 +7218,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EDWIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Edwin2 }
     },
@@ -7232,7 +7232,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EDWIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Edwin3 }
     },
@@ -7246,7 +7246,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EDWIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Edwin4 }
     },
@@ -7260,7 +7260,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EDWIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Edwin5 }
     },
@@ -7540,7 +7540,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BLASIUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaac1 }
     },
@@ -7554,7 +7554,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CLIFF"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Riley }
     },
@@ -7568,7 +7568,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DARIO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Aidan }
     },
@@ -7582,7 +7582,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BLASIUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaac2 }
     },
@@ -7596,7 +7596,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BLASIUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaac3 }
     },
@@ -7610,7 +7610,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BLASIUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaac4 }
     },
@@ -7624,7 +7624,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BLASIUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaac5 }
     },
@@ -7638,7 +7638,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LYDIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lydia1 }
     },
@@ -7652,7 +7652,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DORIS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Alexia }
     },
@@ -7666,7 +7666,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DUNJA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Danielle }
     },
@@ -7680,7 +7680,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LYDIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lydia2 }
     },
@@ -7694,7 +7694,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LYDIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lydia3 }
     },
@@ -7708,7 +7708,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LYDIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lydia4 }
     },
@@ -7722,7 +7722,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LYDIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lydia5 }
     },
@@ -7946,7 +7946,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt28 }
     },
@@ -7960,7 +7960,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt29 }
     },
@@ -7974,7 +7974,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt30 }
     },
@@ -7988,7 +7988,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt31 }
     },
@@ -8002,7 +8002,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt32 }
     },
@@ -8016,7 +8016,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt33 }
     },
@@ -8030,7 +8030,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt34 }
     },
@@ -8044,7 +8044,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt35 }
     },
@@ -8058,7 +8058,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt36 }
     },
@@ -8072,7 +8072,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt37 }
     },
@@ -8086,7 +8086,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt38 }
     },
@@ -8100,7 +8100,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt39 }
     },
@@ -8114,7 +8114,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt40 }
     },
@@ -8128,7 +8128,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt41 }
     },
@@ -8142,7 +8142,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt42 }
     },
@@ -8156,7 +8156,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt43 }
     },
@@ -8170,7 +8170,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt44 }
     },
@@ -8184,7 +8184,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt45 }
     },
@@ -8198,7 +8198,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt46 }
     },
@@ -8212,7 +8212,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt47 }
     },
@@ -8226,7 +8226,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt48 }
     },
@@ -8240,7 +8240,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt49 }
     },
@@ -8254,7 +8254,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt50 }
     },
@@ -8268,7 +8268,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt51 }
     },
@@ -8282,7 +8282,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt52 }
     },
@@ -8296,7 +8296,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt53 }
     },
@@ -8310,7 +8310,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RÜPEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt54 }
     },
@@ -8450,7 +8450,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KARIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tiana }
     },
@@ -8464,7 +8464,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELISA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Haley1 }
     },
@@ -8478,7 +8478,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RICARDA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Janice }
     },
@@ -8506,7 +8506,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELISA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Haley2 }
     },
@@ -8520,7 +8520,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELISA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Haley3 }
     },
@@ -8534,7 +8534,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELISA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Haley4 }
     },
@@ -8548,7 +8548,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELISA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Haley5 }
     },
@@ -8562,7 +8562,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("FREDERIKE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Sally }
     },
@@ -8576,7 +8576,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROBIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Robin }
     },
@@ -8590,7 +8590,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("FRIEDA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Andrea }
     },
@@ -8604,7 +8604,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ADELHEID"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Crissy }
     },
@@ -8618,7 +8618,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BALDUR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Rick }
     },
@@ -8632,7 +8632,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DETWIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lyle }
     },
@@ -8646,7 +8646,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EROS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jose }
     },
@@ -8660,7 +8660,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EUSEBIUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Doug }
     },
@@ -8674,7 +8674,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GANGOLF"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Greg }
     },
@@ -8688,7 +8688,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GERIT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kent }
     },
@@ -8702,7 +8702,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GERNOT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_James1 }
     },
@@ -8716,7 +8716,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GERNOT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_James2 }
     },
@@ -8730,7 +8730,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GERNOT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_James3 }
     },
@@ -8744,7 +8744,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GERNOT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_James4 }
     },
@@ -8758,7 +8758,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GERNOT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_James5 }
     },
@@ -8772,7 +8772,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GISBERT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Brice }
     },
@@ -8786,7 +8786,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HEIMKE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Trent1 }
     },
@@ -8800,7 +8800,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JANNO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lenny }
     },
@@ -8814,7 +8814,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KLODWIG"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lucas1 }
     },
@@ -8828,7 +8828,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LANZELOT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Alan }
     },
@@ -8842,7 +8842,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LUZIUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Clark }
     },
@@ -8856,7 +8856,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MAURIZIO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Eric }
     },
@@ -8870,7 +8870,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KLODWIG"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Lucas2 }
     },
@@ -8884,7 +8884,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MELVIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Mike1 }
     },
@@ -8898,7 +8898,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MELVIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Mike2 }
     },
@@ -8912,7 +8912,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HEIMKE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Trent2 }
     },
@@ -8926,7 +8926,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HEIMKE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Trent3 }
     },
@@ -8940,7 +8940,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HEIMKE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Trent4 }
     },
@@ -8954,7 +8954,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HEIMKE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Trent5 }
     },
@@ -8968,7 +8968,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("INA & LEIF"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_DezAndLuke }
     },
@@ -8982,7 +8982,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LENA & UWE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_LeaAndJed }
     },
@@ -8996,7 +8996,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GESA & PIT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_LoisAndHal1 }
     },
@@ -9010,7 +9010,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GESA & PIT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_LoisAndHal2 }
     },
@@ -9024,7 +9024,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GESA & PIT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_LoisAndHal3 }
     },
@@ -9038,7 +9038,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GESA & PIT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_LoisAndHal4 }
     },
@@ -9052,7 +9052,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GESA & PIT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_LoisAndHal5 }
     },
@@ -9066,7 +9066,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CORDULA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Johanna }
     },
@@ -9094,7 +9094,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BÄRBEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Vivian }
     },
@@ -9108,7 +9108,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CHANTAL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Sadie }
     },
@@ -9122,7 +9122,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SAUL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x3,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Hideo2 }
     },
@@ -9136,7 +9136,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NELSON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x3,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Keigo }
     },
@@ -9150,7 +9150,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NIKODEMUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x3,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemCustomMoves = gTrainerParty_Tsunao }
     },
@@ -9164,7 +9164,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NESTOR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Terrell }
     },
@@ -9178,7 +9178,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MIREILLE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kylee }
     },
@@ -9346,7 +9346,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("OLOF"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jonah }
     },
@@ -9360,7 +9360,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PIUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Henry }
     },
@@ -9374,7 +9374,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("AMATUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Roger }
     },
@@ -9416,7 +9416,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("REMIGIUS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Koji }
     },
@@ -9430,7 +9430,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALVARO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Wayne }
     },
@@ -9444,7 +9444,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("AMALRICH"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Byron }
     },
@@ -9458,7 +9458,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANDOLIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Reed }
     },
@@ -9472,7 +9472,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IMKE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tisha }
     },
@@ -9486,7 +9486,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LI & FLO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_ToriAndTia }
     },
@@ -9500,7 +9500,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ZOE & IRIS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_KimAndIris }
     },
@@ -9514,7 +9514,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TYRA & IVY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_TyraAndIvy }
     },
@@ -9528,7 +9528,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GELI & OLE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_MelAndPaul }
     },
@@ -9612,7 +9612,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TOBI & UNA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_ReliAndIan }
     },
@@ -9626,7 +9626,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TOM & UTA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_RitaAndSam1 }
     },
@@ -9640,7 +9640,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TOM & UTA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_RitaAndSam2 }
     },
@@ -9654,7 +9654,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TOM & UTA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_RitaAndSam3 }
     },
@@ -9668,7 +9668,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TOM & UTA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_RitaAndSam4 }
     },
@@ -9682,7 +9682,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TOM & UTA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_RitaAndSam5 }
     },
@@ -9696,7 +9696,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ERKO & BEA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_LisaAndRay }
     },
@@ -9710,7 +9710,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ABELKE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Eugene }
     },

--- a/src/data/trainers_en.h
+++ b/src/data/trainers_en.h
@@ -8,7 +8,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x0,
+        .aiFlags = 0x7,
         .partySize = 0,
         .party = {.NoItemDefaultMoves = NULL }
     },
@@ -36,7 +36,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt1 }
     },
@@ -50,7 +50,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt2 }
     },
@@ -64,7 +64,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt3 }
     },
@@ -78,7 +78,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt4 }
     },
@@ -92,7 +92,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt5 }
     },
@@ -106,7 +106,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt6 }
     },
@@ -120,7 +120,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt7 }
     },
@@ -134,7 +134,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt8 }
     },
@@ -148,7 +148,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt9 }
     },
@@ -162,7 +162,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt10 }
     },
@@ -176,7 +176,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt11 }
     },
@@ -190,7 +190,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt12 }
     },
@@ -204,7 +204,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt13 }
     },
@@ -218,7 +218,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt14 }
     },
@@ -232,7 +232,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt15 }
     },
@@ -246,7 +246,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt16 }
     },
@@ -260,7 +260,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt17 }
     },
@@ -274,7 +274,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt18 }
     },
@@ -288,7 +288,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt19 }
     },
@@ -302,7 +302,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt20 }
     },
@@ -316,7 +316,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt21 }
     },
@@ -330,7 +330,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt22 }
     },
@@ -344,7 +344,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt23 }
     },
@@ -358,7 +358,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt24 }
     },
@@ -372,7 +372,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt25 }
     },
@@ -386,7 +386,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt26 }
     },
@@ -400,7 +400,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt27 }
     },
@@ -512,7 +512,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DAISY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Daisy }
     },
@@ -526,7 +526,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROSE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Rose1 }
     },
@@ -540,7 +540,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LILY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lily }
     },
@@ -554,7 +554,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("VIOLET"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Violet }
     },
@@ -568,7 +568,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROSE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Rose2 }
     },
@@ -582,7 +582,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROSE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Rose3 }
     },
@@ -596,7 +596,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROSE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Rose4 }
     },
@@ -610,7 +610,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROSE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Rose5 }
     },
@@ -624,7 +624,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DUSTY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Dusty1 }
     },
@@ -638,7 +638,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CHIP"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemCustomMoves = gTrainerParty_Chip }
     },
@@ -652,7 +652,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("FOSTER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Foster }
     },
@@ -666,7 +666,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DUSTY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Dusty2 }
     },
@@ -680,7 +680,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DUSTY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Dusty3 }
     },
@@ -694,7 +694,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DUSTY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Dusty4 }
     },
@@ -708,7 +708,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DUSTY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Dusty5 }
     },
@@ -722,7 +722,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GABBY & TY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_GabbyAndTy1 }
     },
@@ -736,7 +736,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GABBY & TY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_GabbyAndTy2 }
     },
@@ -750,7 +750,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GABBY & TY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_GabbyAndTy3 }
     },
@@ -764,7 +764,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GABBY & TY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_GabbyAndTy4 }
     },
@@ -778,7 +778,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GABBY & TY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_GabbyAndTy5 }
     },
@@ -792,7 +792,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GABBY & TY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_GabbyAndTy6 }
     },
@@ -806,7 +806,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LOLA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lola1 }
     },
@@ -820,7 +820,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CARMEN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Carmen }
     },
@@ -834,7 +834,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GWEN "),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Gwen }
     },
@@ -848,7 +848,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LOLA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lola2 }
     },
@@ -862,7 +862,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LOLA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lola3 }
     },
@@ -876,7 +876,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LOLA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lola4 }
     },
@@ -890,7 +890,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LOLA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lola5 }
     },
@@ -904,7 +904,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RICKY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Ricky1 }
     },
@@ -918,7 +918,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SIMON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Simon }
     },
@@ -932,7 +932,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CHARLIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Charlie }
     },
@@ -946,7 +946,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RICKY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Ricky2 }
     },
@@ -960,7 +960,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RICKY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Ricky3 }
     },
@@ -974,7 +974,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RICKY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Ricky4 }
     },
@@ -988,7 +988,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RICKY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Ricky5 }
     },
@@ -1478,7 +1478,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PATRICIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Patricia }
     },
@@ -1492,7 +1492,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KINDRA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kindra }
     },
@@ -1506,7 +1506,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TAMMY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tammy }
     },
@@ -1520,7 +1520,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("VALERIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Valerie1 }
     },
@@ -1534,7 +1534,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TASHA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tasha }
     },
@@ -1548,7 +1548,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("VALERIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Valerie2 }
     },
@@ -1562,7 +1562,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("VALERIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Valerie3 }
     },
@@ -1576,7 +1576,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("VALERIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Valerie4 }
     },
@@ -1590,7 +1590,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("VALERIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Valerie5 }
     },
@@ -1604,7 +1604,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CINDY"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Cindy1 }
     },
@@ -1618,7 +1618,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous2 }
     },
@@ -1632,7 +1632,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BRIANNA"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Brianna1 }
     },
@@ -1646,7 +1646,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CINDY"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Cindy2 }
     },
@@ -1660,7 +1660,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BRIANNA"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Brianna2 }
     },
@@ -1674,7 +1674,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANETTE"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Anette }
     },
@@ -1688,7 +1688,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CINDY"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Cindy3 }
     },
@@ -1702,7 +1702,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CINDY"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Cindy4 }
     },
@@ -1716,7 +1716,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CINDY"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Cindy5 }
     },
@@ -1730,7 +1730,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CINDY"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemCustomMoves = gTrainerParty_Cindy6 }
     },
@@ -1744,7 +1744,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MELISSA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Melissa }
     },
@@ -1758,7 +1758,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SHEILA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Sheila }
     },
@@ -1772,7 +1772,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SHIRLEY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Shirley }
     },
@@ -1786,7 +1786,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JESSICA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Jessica1 }
     },
@@ -1800,7 +1800,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CONNIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Connie }
     },
@@ -1814,7 +1814,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BRIDGET"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Bridget }
     },
@@ -1828,7 +1828,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("OLIVIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Olivia }
     },
@@ -1842,7 +1842,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TIFFANY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tiffany }
     },
@@ -1856,7 +1856,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JESSICA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Jessica2 }
     },
@@ -1870,7 +1870,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JESSICA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Jessica3 }
     },
@@ -1884,7 +1884,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JESSICA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Jessica4 }
     },
@@ -1898,7 +1898,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JESSICA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Jessica5 }
     },
@@ -1912,7 +1912,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WINSTON"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Winston1 }
     },
@@ -1926,7 +1926,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous3 }
     },
@@ -1940,7 +1940,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GARRET"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Garret }
     },
@@ -1954,7 +1954,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WINSTON"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Winston2 }
     },
@@ -1968,7 +1968,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WINSTON"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Winston3 }
     },
@@ -1982,7 +1982,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WINSTON"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Winston4 }
     },
@@ -1996,7 +1996,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WINSTON"),
         .items = {ITEM_FULL_RESTORE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemCustomMoves = gTrainerParty_Winston5 }
     },
@@ -2010,7 +2010,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("STEVE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Steve1 }
     },
@@ -2024,7 +2024,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CHRIS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Chris }
     },
@@ -2038,7 +2038,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MARK"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Mark }
     },
@@ -2052,7 +2052,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KENN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kenn }
     },
@@ -2066,7 +2066,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("STEVE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Steve2 }
     },
@@ -2080,7 +2080,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("STEVE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Steve3 }
     },
@@ -2094,7 +2094,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("STEVE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Steve4 }
     },
@@ -2108,7 +2108,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("STEVE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Steve5 }
     },
@@ -2122,7 +2122,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LUIS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Luis }
     },
@@ -2136,7 +2136,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("AUSTIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Austin }
     },
@@ -2150,7 +2150,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DOUGLAS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Douglas }
     },
@@ -2164,7 +2164,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DARRIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Darrin }
     },
@@ -2178,7 +2178,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TONY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tony1 }
     },
@@ -2192,7 +2192,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JEROME"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jerome }
     },
@@ -2206,7 +2206,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MATTHEW"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Matthew }
     },
@@ -2220,7 +2220,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DAVID"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_David }
     },
@@ -2234,7 +2234,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SPENCER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Spencer }
     },
@@ -2248,7 +2248,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROLAND"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Roland }
     },
@@ -2262,7 +2262,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CODY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cody }
     },
@@ -2276,7 +2276,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("STAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Stan }
     },
@@ -2290,7 +2290,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BARRY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Barry }
     },
@@ -2304,7 +2304,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DEAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dean }
     },
@@ -2318,7 +2318,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RODNEY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Rodney }
     },
@@ -2332,7 +2332,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RICHARD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Richard }
     },
@@ -2346,7 +2346,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HERMAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Herman }
     },
@@ -2360,7 +2360,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous4 }
     },
@@ -2374,7 +2374,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GILBERT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Gilbert }
     },
@@ -2388,7 +2388,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("FRANKLIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Franklin }
     },
@@ -2402,7 +2402,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DANNY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Danny }
     },
@@ -2416,7 +2416,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JACK"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jack }
     },
@@ -2430,7 +2430,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DUDLEY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dudley }
     },
@@ -2444,7 +2444,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CHAD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Chad }
     },
@@ -2458,7 +2458,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TONY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tony2 }
     },
@@ -2472,7 +2472,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TONY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tony3 }
     },
@@ -2486,7 +2486,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TONY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tony4 }
     },
@@ -2500,7 +2500,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TONY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tony5 }
     },
@@ -2514,7 +2514,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HIDEKI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Hideki }
     },
@@ -2528,7 +2528,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HITOSHI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Hitoshi }
     },
@@ -2542,7 +2542,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KIYO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kiyo }
     },
@@ -2556,7 +2556,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KOICHI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Koichi }
     },
@@ -2570,7 +2570,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NOB"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nob1 }
     },
@@ -2584,7 +2584,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NOB"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nob2 }
     },
@@ -2598,7 +2598,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NOB"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nob3 }
     },
@@ -2612,7 +2612,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NOB"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nob4 }
     },
@@ -2626,7 +2626,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NOB"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.ItemDefaultMoves = gTrainerParty_Nob5 }
     },
@@ -2640,7 +2640,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("YUJI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Yuji }
     },
@@ -2654,7 +2654,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DAISUKE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Daisuke }
     },
@@ -2668,7 +2668,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ATSUSHI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Atsushi }
     },
@@ -2682,7 +2682,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KIRK"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kirk }
     },
@@ -2696,7 +2696,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SCOTT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Scott }
     },
@@ -2710,7 +2710,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HARVEY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Harvey }
     },
@@ -2724,7 +2724,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SHAWN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Shawn }
     },
@@ -2738,7 +2738,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RANDY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Randy }
     },
@@ -2752,7 +2752,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DALTON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dalton1 }
     },
@@ -2766,7 +2766,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DALTON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dalton2 }
     },
@@ -2780,7 +2780,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DALTON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dalton3 }
     },
@@ -2794,7 +2794,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DALTON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dalton4 }
     },
@@ -2808,7 +2808,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DALTON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dalton5 }
     },
@@ -2822,7 +2822,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("COLE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cole }
     },
@@ -2836,7 +2836,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("FLINT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Flint }
     },
@@ -2850,7 +2850,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("AXLE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Axle }
     },
@@ -2864,7 +2864,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JAKE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jake }
     },
@@ -2878,7 +2878,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANDY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Andy }
     },
@@ -2892,7 +2892,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BERNIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Bernie1 }
     },
@@ -2906,7 +2906,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BERNIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Bernie2 }
     },
@@ -2920,7 +2920,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BERNIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Bernie3 }
     },
@@ -2934,7 +2934,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BERNIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Bernie4 }
     },
@@ -2948,7 +2948,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BERNIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Bernie5 }
     },
@@ -2962,7 +2962,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DREW"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Drew }
     },
@@ -2976,7 +2976,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CLIFF"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemCustomMoves = gTrainerParty_Cliff }
     },
@@ -2990,7 +2990,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LARRY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Larry }
     },
@@ -3004,7 +3004,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SHANE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Shane }
     },
@@ -3018,7 +3018,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JUSTIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Justin }
     },
@@ -3032,7 +3032,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ETHAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ethan1 }
     },
@@ -3046,7 +3046,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JEFF"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jeff }
     },
@@ -3060,7 +3060,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TRAVIS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Travis }
     },
@@ -3074,7 +3074,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ETHAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ethan2 }
     },
@@ -3088,7 +3088,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ETHAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ethan3 }
     },
@@ -3102,7 +3102,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ETHAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ethan4 }
     },
@@ -3116,7 +3116,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ETHAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ethan5 }
     },
@@ -3130,7 +3130,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BRENT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Brent }
     },
@@ -3144,7 +3144,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DONALD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Donald }
     },
@@ -3158,7 +3158,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TAYLOR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Taylor }
     },
@@ -3172,7 +3172,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BRANDON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Brandon1 }
     },
@@ -3186,7 +3186,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DEREK"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Derek }
     },
@@ -3200,7 +3200,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BRANDON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Brandon2 }
     },
@@ -3214,7 +3214,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BRANDON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Brandon3 }
     },
@@ -3228,7 +3228,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BRANDON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Brandon4 }
     },
@@ -3242,7 +3242,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BRANDON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 5,
         .party = {.ItemDefaultMoves = gTrainerParty_Brandon5 }
     },
@@ -3256,7 +3256,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EDWARD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Edward }
     },
@@ -3270,7 +3270,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PRESTON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Preston }
     },
@@ -3284,7 +3284,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("VIRGIL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Virgil }
     },
@@ -3298,7 +3298,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("FRITZ"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Fritz }
     },
@@ -3312,7 +3312,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WILLIAM"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_William }
     },
@@ -3326,7 +3326,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JOSHUA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Joshua }
     },
@@ -3340,7 +3340,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CAMERON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cameron1 }
     },
@@ -3354,7 +3354,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CAMERON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cameron2 }
     },
@@ -3368,7 +3368,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CAMERON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cameron3 }
     },
@@ -3382,7 +3382,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CAMERON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cameron4 }
     },
@@ -3396,7 +3396,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CAMERON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cameron5 }
     },
@@ -3410,7 +3410,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JACLYN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Jaclyn }
     },
@@ -3424,7 +3424,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HANNAH"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Hannah }
     },
@@ -3438,7 +3438,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SAMANTHA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Samantha }
     },
@@ -3452,7 +3452,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MAURA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Maura }
     },
@@ -3466,7 +3466,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KAYLA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kayla }
     },
@@ -3480,7 +3480,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALEXIS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Alexis }
     },
@@ -3494,7 +3494,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JACKI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jacki1 }
     },
@@ -3508,7 +3508,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JACKI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jacki2 }
     },
@@ -3522,7 +3522,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JACKI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jacki3 }
     },
@@ -3536,7 +3536,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JACKI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jacki4 }
     },
@@ -3550,7 +3550,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JACKI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jacki5 }
     },
@@ -3564,7 +3564,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WALTER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Walter1 }
     },
@@ -3578,7 +3578,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TUCKER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tucker }
     },
@@ -3592,7 +3592,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("THOMAS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Thomas }
     },
@@ -3606,7 +3606,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WALTER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Walter2 }
     },
@@ -3620,7 +3620,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WALTER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Walter3 }
     },
@@ -3634,7 +3634,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WALTER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Walter4 }
     },
@@ -3648,7 +3648,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WALTER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemCustomMoves = gTrainerParty_Walter5 }
     },
@@ -3830,7 +3830,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JERRY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jerry1 }
     },
@@ -3844,7 +3844,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TED"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ted }
     },
@@ -3858,7 +3858,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PAUL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Paul }
     },
@@ -3872,7 +3872,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JERRY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jerry2 }
     },
@@ -3886,7 +3886,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JERRY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jerry3 }
     },
@@ -3900,7 +3900,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JERRY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jerry4 }
     },
@@ -3914,7 +3914,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JERRY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jerry5 }
     },
@@ -3928,7 +3928,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KAREN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Karen1 }
     },
@@ -3942,7 +3942,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GEORGIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Georgia }
     },
@@ -3956,7 +3956,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KAREN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Karen2 }
     },
@@ -3970,7 +3970,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KAREN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Karen3 }
     },
@@ -3984,7 +3984,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KAREN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Karen4 }
     },
@@ -3998,7 +3998,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KAREN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Karen5 }
     },
@@ -4012,7 +4012,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KATE & JOY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_KateAndJoy }
     },
@@ -4026,7 +4026,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANNA & MEG"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_AnnaAndMeg1 }
     },
@@ -4040,7 +4040,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANNA & MEG"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_AnnaAndMeg2 }
     },
@@ -4054,7 +4054,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANNA & MEG"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_AnnaAndMeg3 }
     },
@@ -4068,7 +4068,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANNA & MEG"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_AnnaAndMeg4 }
     },
@@ -4082,7 +4082,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANNA & MEG"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_AnnaAndMeg5 }
     },
@@ -4096,7 +4096,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("VICTOR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.ItemDefaultMoves = gTrainerParty_Victor }
     },
@@ -4110,7 +4110,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MIGUEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Miguel1 }
     },
@@ -4124,7 +4124,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("COLTON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.ItemCustomMoves = gTrainerParty_Colton }
     },
@@ -4138,7 +4138,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MIGUEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Miguel2 }
     },
@@ -4152,7 +4152,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MIGUEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Miguel3 }
     },
@@ -4166,7 +4166,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MIGUEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Miguel4 }
     },
@@ -4180,7 +4180,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MIGUEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Miguel5 }
     },
@@ -4194,7 +4194,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("VICTORIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x3,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Victoria }
     },
@@ -4208,7 +4208,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("VANESSA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.ItemDefaultMoves = gTrainerParty_Vanessa }
     },
@@ -4222,7 +4222,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MARISSA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.ItemDefaultMoves = gTrainerParty_Marissa }
     },
@@ -4236,7 +4236,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISABEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.ItemDefaultMoves = gTrainerParty_Isabel1 }
     },
@@ -4250,7 +4250,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISABEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.ItemDefaultMoves = gTrainerParty_Isabel2 }
     },
@@ -4264,7 +4264,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISABEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.ItemDefaultMoves = gTrainerParty_Isabel3 }
     },
@@ -4278,7 +4278,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISABEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.ItemDefaultMoves = gTrainerParty_Isabel4 }
     },
@@ -4292,7 +4292,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISABEL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.ItemDefaultMoves = gTrainerParty_Isabel5 }
     },
@@ -4460,7 +4460,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CALVIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Calvin1 }
     },
@@ -4474,7 +4474,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BILLY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Billy }
     },
@@ -4488,7 +4488,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JOSH"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemCustomMoves = gTrainerParty_Josh }
     },
@@ -4502,7 +4502,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TOMMY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tommy }
     },
@@ -4516,7 +4516,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JOEY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Joey }
     },
@@ -4530,7 +4530,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BEN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Ben }
     },
@@ -4544,7 +4544,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous5 }
     },
@@ -4558,7 +4558,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KEVIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kevin }
     },
@@ -4572,7 +4572,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NEAL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Neal }
     },
@@ -4586,7 +4586,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DILLON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dillon }
     },
@@ -4600,7 +4600,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CALVIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Calvin2 }
     },
@@ -4614,7 +4614,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CALVIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Calvin3 }
     },
@@ -4628,7 +4628,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CALVIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Calvin4 }
     },
@@ -4642,7 +4642,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CALVIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Calvin5 }
     },
@@ -4656,7 +4656,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EDDIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Eddie }
     },
@@ -4670,7 +4670,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALLEN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Allen }
     },
@@ -4684,7 +4684,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TIMMY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Timmy }
     },
@@ -4712,7 +4712,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANDREW"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Andrew }
     },
@@ -4726,7 +4726,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IVAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ivan }
     },
@@ -4740,7 +4740,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CLAUDE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Claude }
     },
@@ -4754,7 +4754,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELLIOT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Elliot1 }
     },
@@ -4768,7 +4768,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NED"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ned }
     },
@@ -4782,7 +4782,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DALE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dale }
     },
@@ -4796,7 +4796,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NOLAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nolan }
     },
@@ -4810,7 +4810,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BARNY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Barny }
     },
@@ -4824,7 +4824,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WADE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Wade }
     },
@@ -4838,7 +4838,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CARTER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Carter }
     },
@@ -4852,7 +4852,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELLIOT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Elliot2 }
     },
@@ -4866,7 +4866,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELLIOT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Elliot3 }
     },
@@ -4880,7 +4880,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELLIOT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Elliot4 }
     },
@@ -4894,7 +4894,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ELLIOT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x3,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Elliot5 }
     },
@@ -4908,7 +4908,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RONALD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ronald }
     },
@@ -4922,7 +4922,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JACOB"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jacob }
     },
@@ -4936,7 +4936,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANTHONY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anthony }
     },
@@ -4950,7 +4950,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BENJAMIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Benjamin1 }
     },
@@ -4964,7 +4964,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BENJAMIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Benjamin2 }
     },
@@ -4978,7 +4978,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BENJAMIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Benjamin3 }
     },
@@ -4992,7 +4992,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BENJAMIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Benjamin4 }
     },
@@ -5006,7 +5006,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BENJAMIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Benjamin5 }
     },
@@ -5020,7 +5020,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ABIGAIL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Abigail1 }
     },
@@ -5034,7 +5034,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JASMINE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jasmine }
     },
@@ -5048,7 +5048,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ABIGAIL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Abigail2 }
     },
@@ -5062,7 +5062,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ABIGAIL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Abigail3 }
     },
@@ -5076,7 +5076,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ABIGAIL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Abigail4 }
     },
@@ -5090,7 +5090,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ABIGAIL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Abigail5 }
     },
@@ -5104,7 +5104,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DYLAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dylan1 }
     },
@@ -5118,7 +5118,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DYLAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dylan2 }
     },
@@ -5132,7 +5132,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DYLAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dylan3 }
     },
@@ -5146,7 +5146,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DYLAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dylan4 }
     },
@@ -5160,7 +5160,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DYLAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dylan5 }
     },
@@ -5174,7 +5174,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MARIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Maria1 }
     },
@@ -5188,7 +5188,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MARIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Maria2 }
     },
@@ -5202,7 +5202,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MARIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Maria3 }
     },
@@ -5216,7 +5216,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MARIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Maria4 }
     },
@@ -5230,7 +5230,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MARIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Maria5 }
     },
@@ -5244,7 +5244,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CALEB"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Caleb }
     },
@@ -5258,7 +5258,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous6 }
     },
@@ -5272,7 +5272,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISAIAH"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaiah1 }
     },
@@ -5286,7 +5286,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous7 }
     },
@@ -5300,7 +5300,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CHASE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Chase }
     },
@@ -5314,7 +5314,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISAIAH"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaiah2 }
     },
@@ -5328,7 +5328,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISAIAH"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaiah3 }
     },
@@ -5342,7 +5342,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISAIAH"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaiah4 }
     },
@@ -5356,7 +5356,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISAIAH"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaiah5 }
     },
@@ -5370,7 +5370,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous8 }
     },
@@ -5384,7 +5384,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CONNOR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Connor }
     },
@@ -5398,7 +5398,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous9 }
     },
@@ -5412,7 +5412,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KATELYN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Katelyn1 }
     },
@@ -5426,7 +5426,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALLISON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Allison }
     },
@@ -5440,7 +5440,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KATELYN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Katelyn2 }
     },
@@ -5454,7 +5454,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KATELYN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Katelyn3 }
     },
@@ -5468,7 +5468,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KATELYN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Katelyn4 }
     },
@@ -5482,7 +5482,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KATELYN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Katelyn5 }
     },
@@ -5496,7 +5496,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NICOLAS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nicolas1 }
     },
@@ -5510,7 +5510,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NICOLAS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nicolas2 }
     },
@@ -5524,7 +5524,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NICOLAS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nicolas3 }
     },
@@ -5538,7 +5538,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NICOLAS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nicolas4 }
     },
@@ -5552,7 +5552,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NICOLAS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.ItemDefaultMoves = gTrainerParty_Nicolas5 }
     },
@@ -5566,7 +5566,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("AARON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Aaron }
     },
@@ -5580,7 +5580,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PERRY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Perry }
     },
@@ -5594,7 +5594,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HUGH"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Hugh }
     },
@@ -5608,7 +5608,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PHIL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Phil }
     },
@@ -5622,7 +5622,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JARED"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jared }
     },
@@ -5636,7 +5636,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous10 }
     },
@@ -5650,7 +5650,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TANNER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tanner }
     },
@@ -5664,7 +5664,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WILL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Will }
     },
@@ -5678,7 +5678,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("COLIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Colin }
     },
@@ -5692,7 +5692,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROBERT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Robert1 }
     },
@@ -5706,7 +5706,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BENNY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Benny }
     },
@@ -5720,7 +5720,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CHESTER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Chester }
     },
@@ -5734,7 +5734,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROBERT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Robert2 }
     },
@@ -5748,7 +5748,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROBERT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Robert3 }
     },
@@ -5762,7 +5762,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROBERT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Robert4 }
     },
@@ -5776,7 +5776,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROBERT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Robert5 }
     },
@@ -5790,7 +5790,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALEX"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Alex }
     },
@@ -5804,7 +5804,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BECK"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Beck }
     },
@@ -5818,7 +5818,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("YASU"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x3,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Yasu }
     },
@@ -5832,7 +5832,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TAKASHI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x3,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Takashi }
     },
@@ -5846,7 +5846,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MAKOTO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x0,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Makoto }
     },
@@ -5860,7 +5860,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HIDEO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x0,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Hideo1 }
     },
@@ -5874,7 +5874,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LAO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x0,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemCustomMoves = gTrainerParty_Lao1 }
     },
@@ -5888,7 +5888,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LUNG"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x0,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lung }
     },
@@ -5902,7 +5902,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LAO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x0,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemCustomMoves = gTrainerParty_Lao2 }
     },
@@ -5916,7 +5916,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LAO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x0,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemCustomMoves = gTrainerParty_Lao3 }
     },
@@ -5930,7 +5930,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LAO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x0,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemCustomMoves = gTrainerParty_Lao4 }
     },
@@ -5944,7 +5944,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LAO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x0,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.ItemCustomMoves = gTrainerParty_Lao5 }
     },
@@ -5958,7 +5958,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TESSA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tessa }
     },
@@ -5972,7 +5972,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LAURA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Laura }
     },
@@ -5986,7 +5986,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CYNDY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cyndy1 }
     },
@@ -6000,7 +6000,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CORA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cora }
     },
@@ -6014,7 +6014,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JILL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jill }
     },
@@ -6028,7 +6028,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CYNDY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cyndy2 }
     },
@@ -6042,7 +6042,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CYNDY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cyndy3 }
     },
@@ -6056,7 +6056,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CYNDY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cyndy4 }
     },
@@ -6070,7 +6070,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CYNDY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Cyndy5 }
     },
@@ -6084,7 +6084,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MADELINE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Madeline1 }
     },
@@ -6098,7 +6098,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CLARISSA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Clarissa }
     },
@@ -6112,7 +6112,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANGELICA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Angelica }
     },
@@ -6126,7 +6126,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MADELINE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Madeline2 }
     },
@@ -6140,7 +6140,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MADELINE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Madeline3 }
     },
@@ -6154,7 +6154,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MADELINE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Madeline4 }
     },
@@ -6168,7 +6168,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MADELINE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Madeline5 }
     },
@@ -6182,7 +6182,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BEVERLY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Beverly }
     },
@@ -6196,7 +6196,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DAWN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dawn }
     },
@@ -6210,7 +6210,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NICOLE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nicole }
     },
@@ -6224,7 +6224,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DENISE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Denise }
     },
@@ -6238,7 +6238,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BETH"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Beth }
     },
@@ -6252,7 +6252,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TARA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tara }
     },
@@ -6266,7 +6266,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MISSY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Missy }
     },
@@ -6280,7 +6280,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALICE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Alice }
     },
@@ -6294,7 +6294,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JENNY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jenny1 }
     },
@@ -6308,7 +6308,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRACE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grace }
     },
@@ -6322,7 +6322,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TANYA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tanya }
     },
@@ -6336,7 +6336,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SHARON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Sharon }
     },
@@ -6350,7 +6350,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NIKKI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nikki }
     },
@@ -6364,7 +6364,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BRENDA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Brenda }
     },
@@ -6378,7 +6378,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KATIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Katie }
     },
@@ -6392,7 +6392,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SUSIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Susie }
     },
@@ -6406,7 +6406,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KARA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kara }
     },
@@ -6420,7 +6420,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DANA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dana }
     },
@@ -6434,7 +6434,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ERIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Erin }
     },
@@ -6448,7 +6448,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DEBRA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Debra }
     },
@@ -6462,7 +6462,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LINDA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Linda }
     },
@@ -6476,7 +6476,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KAYLEE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kaylee }
     },
@@ -6490,7 +6490,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LAUREL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Laurel }
     },
@@ -6504,7 +6504,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DARCY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Darcy }
     },
@@ -6518,7 +6518,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JENNY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jenny2 }
     },
@@ -6532,7 +6532,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JENNY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jenny3 }
     },
@@ -6546,7 +6546,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JENNY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jenny4 }
     },
@@ -6560,7 +6560,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JENNY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jenny5 }
     },
@@ -6574,7 +6574,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HEIDI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Heidi }
     },
@@ -6588,7 +6588,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BECKY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Becky }
     },
@@ -6602,7 +6602,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CAROL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Carol }
     },
@@ -6616,7 +6616,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NANCY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nancy }
     },
@@ -6630,7 +6630,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MARTHA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Martha }
     },
@@ -6644,7 +6644,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DIANA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Diana1 }
     },
@@ -6658,7 +6658,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("NINA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Nina }
     },
@@ -6672,7 +6672,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("IRENE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Irene }
     },
@@ -6686,7 +6686,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DIANA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Diana2 }
     },
@@ -6700,7 +6700,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DIANA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Diana3 }
     },
@@ -6714,7 +6714,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DIANA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Diana4 }
     },
@@ -6728,7 +6728,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DIANA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Diana5 }
     },
@@ -6742,7 +6742,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("AMY & LIV"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_AmyAndLiv1 }
     },
@@ -6756,7 +6756,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("AMY & LIV"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_AmyAndLiv2 }
     },
@@ -6770,7 +6770,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GINA & MIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_GinaAndMia1 }
     },
@@ -6784,7 +6784,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MIU & YUKI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_MiuAndYuki }
     },
@@ -6798,7 +6798,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("AMY & LIV"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_AmyAndLiv3 }
     },
@@ -6812,7 +6812,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GINA & MIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_GinaAndMia2 }
     },
@@ -6826,7 +6826,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("AMY & LIV"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_AmyAndLiv4 }
     },
@@ -6840,7 +6840,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("AMY & LIV"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_AmyAndLiv5 }
     },
@@ -6854,7 +6854,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("AMY & LIV"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_AmyAndLiv6 }
     },
@@ -6868,7 +6868,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HUEY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Huey }
     },
@@ -6882,7 +6882,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EDMOND"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Edmond }
     },
@@ -6896,7 +6896,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ERNEST"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ernest1 }
     },
@@ -6910,7 +6910,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DWAYNE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Dwayne }
     },
@@ -6924,7 +6924,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PHILLIP"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Phillip }
     },
@@ -6938,7 +6938,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LEONARD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Leonard }
     },
@@ -6952,7 +6952,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DUNCAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Duncan }
     },
@@ -6966,7 +6966,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ERNEST"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ernest2 }
     },
@@ -6980,7 +6980,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ERNEST"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ernest3 }
     },
@@ -6994,7 +6994,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ERNEST"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ernest4 }
     },
@@ -7008,7 +7008,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ERNEST"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Ernest5 }
     },
@@ -7022,7 +7022,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous11 }
     },
@@ -7036,7 +7036,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous12 }
     },
@@ -7050,7 +7050,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _(""),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Anonymous13 }
     },
@@ -7064,7 +7064,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SONNY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Sonny }
     },
@@ -7078,7 +7078,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DONOVAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Donovan }
     },
@@ -7092,7 +7092,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GERALD"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Gerald }
     },
@@ -7106,7 +7106,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KELVIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kelvin }
     },
@@ -7120,7 +7120,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KODY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kody }
     },
@@ -7134,7 +7134,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TEVIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tevin }
     },
@@ -7148,7 +7148,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DAMON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Damon }
     },
@@ -7162,7 +7162,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("PABLO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Pablo }
     },
@@ -7176,7 +7176,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EDWIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Edwin1 }
     },
@@ -7190,7 +7190,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HECTOR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Hector1 }
     },
@@ -7204,7 +7204,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HECTOR"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Hector2 }
     },
@@ -7218,7 +7218,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EDWIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Edwin2 }
     },
@@ -7232,7 +7232,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EDWIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Edwin3 }
     },
@@ -7246,7 +7246,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EDWIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Edwin4 }
     },
@@ -7260,7 +7260,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EDWIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Edwin5 }
     },
@@ -7540,7 +7540,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISAAC"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaac1 }
     },
@@ -7554,7 +7554,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RILEY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Riley }
     },
@@ -7568,7 +7568,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("AIDAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Aidan }
     },
@@ -7582,7 +7582,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISAAC"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaac2 }
     },
@@ -7596,7 +7596,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISAAC"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaac3 }
     },
@@ -7610,7 +7610,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISAAC"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaac4 }
     },
@@ -7624,7 +7624,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ISAAC"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Isaac5 }
     },
@@ -7638,7 +7638,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LYDIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lydia1 }
     },
@@ -7652,7 +7652,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALEXIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Alexia }
     },
@@ -7666,7 +7666,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DANIELLE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Danielle }
     },
@@ -7680,7 +7680,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LYDIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lydia2 }
     },
@@ -7694,7 +7694,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LYDIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lydia3 }
     },
@@ -7708,7 +7708,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LYDIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lydia4 }
     },
@@ -7722,7 +7722,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LYDIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lydia5 }
     },
@@ -7946,7 +7946,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt28 }
     },
@@ -7960,7 +7960,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt29 }
     },
@@ -7974,7 +7974,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt30 }
     },
@@ -7988,7 +7988,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt31 }
     },
@@ -8002,7 +8002,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt32 }
     },
@@ -8016,7 +8016,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt33 }
     },
@@ -8030,7 +8030,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt34 }
     },
@@ -8044,7 +8044,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt35 }
     },
@@ -8058,7 +8058,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt36 }
     },
@@ -8072,7 +8072,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt37 }
     },
@@ -8086,7 +8086,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt38 }
     },
@@ -8100,7 +8100,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt39 }
     },
@@ -8114,7 +8114,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt40 }
     },
@@ -8128,7 +8128,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt41 }
     },
@@ -8142,7 +8142,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt42 }
     },
@@ -8156,7 +8156,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt43 }
     },
@@ -8170,7 +8170,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt44 }
     },
@@ -8184,7 +8184,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt45 }
     },
@@ -8198,7 +8198,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt46 }
     },
@@ -8212,7 +8212,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt47 }
     },
@@ -8226,7 +8226,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt48 }
     },
@@ -8240,7 +8240,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt49 }
     },
@@ -8254,7 +8254,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt50 }
     },
@@ -8268,7 +8268,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt51 }
     },
@@ -8282,7 +8282,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt52 }
     },
@@ -8296,7 +8296,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt53 }
     },
@@ -8310,7 +8310,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GRUNT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Grunt54 }
     },
@@ -8450,7 +8450,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TIANA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tiana }
     },
@@ -8464,7 +8464,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HALEY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Haley1 }
     },
@@ -8478,7 +8478,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JANICE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Janice }
     },
@@ -8506,7 +8506,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HALEY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Haley2 }
     },
@@ -8520,7 +8520,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HALEY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Haley3 }
     },
@@ -8534,7 +8534,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HALEY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Haley4 }
     },
@@ -8548,7 +8548,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HALEY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Haley5 }
     },
@@ -8562,7 +8562,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SALLY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Sally }
     },
@@ -8576,7 +8576,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROBIN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Robin }
     },
@@ -8590,7 +8590,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ANDREA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Andrea }
     },
@@ -8604,7 +8604,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CRISSY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Crissy }
     },
@@ -8618,7 +8618,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RICK"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Rick }
     },
@@ -8632,7 +8632,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LYLE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 6,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lyle }
     },
@@ -8646,7 +8646,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JOSE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jose }
     },
@@ -8660,7 +8660,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DOUG"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Doug }
     },
@@ -8674,7 +8674,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("GREG"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Greg }
     },
@@ -8688,7 +8688,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KENT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kent }
     },
@@ -8702,7 +8702,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JAMES"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_James1 }
     },
@@ -8716,7 +8716,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JAMES"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_James2 }
     },
@@ -8730,7 +8730,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JAMES"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_James3 }
     },
@@ -8744,7 +8744,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JAMES"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_James4 }
     },
@@ -8758,7 +8758,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JAMES"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_James5 }
     },
@@ -8772,7 +8772,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BRICE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Brice }
     },
@@ -8786,7 +8786,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TRENT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Trent1 }
     },
@@ -8800,7 +8800,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LENNY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lenny }
     },
@@ -8814,7 +8814,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LUCAS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Lucas1 }
     },
@@ -8828,7 +8828,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ALAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Alan }
     },
@@ -8842,7 +8842,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("CLARK"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Clark }
     },
@@ -8856,7 +8856,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ERIC"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Eric }
     },
@@ -8870,7 +8870,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LUCAS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Lucas2 }
     },
@@ -8884,7 +8884,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MIKE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Mike1 }
     },
@@ -8898,7 +8898,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MIKE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Mike2 }
     },
@@ -8912,7 +8912,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TRENT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Trent2 }
     },
@@ -8926,7 +8926,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TRENT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Trent3 }
     },
@@ -8940,7 +8940,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TRENT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Trent4 }
     },
@@ -8954,7 +8954,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TRENT"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Trent5 }
     },
@@ -8968,7 +8968,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("DEZ & LUKE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_DezAndLuke }
     },
@@ -8982,7 +8982,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LEA & JED"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_LeaAndJed }
     },
@@ -8996,7 +8996,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LOIS & HAL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_LoisAndHal1 }
     },
@@ -9010,7 +9010,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LOIS & HAL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_LoisAndHal2 }
     },
@@ -9024,7 +9024,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LOIS & HAL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_LoisAndHal3 }
     },
@@ -9038,7 +9038,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LOIS & HAL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_LoisAndHal4 }
     },
@@ -9052,7 +9052,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LOIS & HAL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_LoisAndHal5 }
     },
@@ -9066,7 +9066,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JOHANNA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Johanna }
     },
@@ -9094,7 +9094,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("VIVIAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Vivian }
     },
@@ -9108,7 +9108,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("SADIE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemCustomMoves = gTrainerParty_Sadie }
     },
@@ -9122,7 +9122,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HIDEO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x3,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Hideo2 }
     },
@@ -9136,7 +9136,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KEIGO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x3,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_Keigo }
     },
@@ -9150,7 +9150,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TSUNAO"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x3,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemCustomMoves = gTrainerParty_Tsunao }
     },
@@ -9164,7 +9164,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TERRELL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Terrell }
     },
@@ -9178,7 +9178,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KYLEE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 1,
         .party = {.NoItemDefaultMoves = gTrainerParty_Kylee }
     },
@@ -9346,7 +9346,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("JONAH"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Jonah }
     },
@@ -9360,7 +9360,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("HENRY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Henry }
     },
@@ -9374,7 +9374,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("ROGER"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Roger }
     },
@@ -9416,7 +9416,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KOJI"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Koji }
     },
@@ -9430,7 +9430,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("WAYNE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Wayne }
     },
@@ -9444,7 +9444,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("BYRON"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_Byron }
     },
@@ -9458,7 +9458,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("REED"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Reed }
     },
@@ -9472,7 +9472,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TISHA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 3,
         .party = {.NoItemDefaultMoves = gTrainerParty_Tisha }
     },
@@ -9486,7 +9486,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TORI & TIA"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_ToriAndTia }
     },
@@ -9500,7 +9500,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("KIM & IRIS"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_KimAndIris }
     },
@@ -9514,7 +9514,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("TYRA & IVY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_TyraAndIvy }
     },
@@ -9528,7 +9528,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("MEL & PAUL"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemCustomMoves = gTrainerParty_MelAndPaul }
     },
@@ -9612,7 +9612,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RELI & IAN"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_ReliAndIan }
     },
@@ -9626,7 +9626,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RITA & SAM"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_RitaAndSam1 }
     },
@@ -9640,7 +9640,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RITA & SAM"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_RitaAndSam2 }
     },
@@ -9654,7 +9654,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RITA & SAM"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_RitaAndSam3 }
     },
@@ -9668,7 +9668,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RITA & SAM"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_RitaAndSam4 }
     },
@@ -9682,7 +9682,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("RITA & SAM"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_RitaAndSam5 }
     },
@@ -9696,7 +9696,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("LISA & RAY"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = TRUE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 2,
         .party = {.NoItemDefaultMoves = gTrainerParty_LisaAndRay }
     },
@@ -9710,7 +9710,7 @@ const struct Trainer gTrainers[] = {
         .trainerName = _("EUGENE"),
         .items = {ITEM_NONE, ITEM_NONE, ITEM_NONE, ITEM_NONE},
         .doubleBattle = FALSE,
-        .aiFlags = 0x1,
+        .aiFlags = 0x7,
         .partySize = 4,
         .party = {.NoItemDefaultMoves = gTrainerParty_Eugene }
     },


### PR DESCRIPTION
# Stronger Trainers

## Gameplay Changes
- Make trainer Pokemons stronger (increased IVs).
- Improve trainer AI slightly.

## Source Changes
- Set IV level of all trainer Pokemon in `src/data/trainer_parties.h` to the maximum (255).
- Set aiFlags to `0x7` for all trainers in `src/data/trainers_de.h`.
- Set aiFlags to `0x7` for all trainers in `src/data/trainers_en.h`.