### PR TITLE
Mirage Island

### DIFF
--- a/src/time_events.c
+++ b/src/time_events.c
@@ -41,14 +41,11 @@ void UpdateMirageRnd(u16 days)
 
 bool8 IsMirageIslandPresent(void)
 {
-    u16 rnd = GetMirageRnd() >> 16;
-    int i;
-
-    for (i = 0; i < PARTY_SIZE; i++)
-        if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES) && (GetMonData(&gPlayerParty[i], MON_DATA_PERSONALITY) & 0xFFFF) == rnd)
-            return TRUE;
-
-    return FALSE;
+    if (GetGameStat(GAME_STAT_ENTERED_HOF) > 0) {
+        return 1;
+    } else {
+        return 0;
+    }
 }
 
 void UpdateShoalTideFlag(void)


### PR DESCRIPTION
# Mirage Island

## Gameplay Changes
- Make mirage island accessible after the elite four.

## Source Changes
- In `src/time_events.c`, check wether game stat `ENTERED_HOF` is larger than zero. If yes, show mirage island.